### PR TITLE
fix: remove edited type from workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     # actually creating releases for terraform modules in this primary github action
     # repository. Thus, we ensure that the "closed" option is not present. Separately,
     # we test the action as designed in a separate terraform-module repository.
-    types: [opened, edited, synchronize]
+    types: [opened, reopened, synchronize]
     branches:
       - main
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Add the following YAML to your `.github/workflows` directory:
 name: Terraform Module Releaser
 on:
   pull_request:
-    types: [opened, edited, synchronize, closed] # Closed required
+    types: [opened, reopened, synchronize, closed] # Closed required
     branches:
       - main
 
@@ -152,7 +152,7 @@ resources.
 name: Terraform Module Releaser
 on:
   pull_request:
-    types: [opened, edited, synchronize, closed] # Closed required
+    types: [opened, reopened, synchronize, closed] # Closed required
     branches:
       - main
 


### PR DESCRIPTION
- Updated the GitHub Action to trigger on reopened events instead of edited.
- Removed unnecessary retriggers caused by PR title/body updates, focusing on keeping PR comments up-to-date.

Fixes #7 