### PR TITLE
fix(license): update copyright year and owner name in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright GitHub
+Copyright (c) 2024 TechPivot
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- Updated the copyright year in the LICENSE file to reflect the current year (2024).
- Changed the owner name to "TechPivot" for accuracy.

This change ensures that the legal information in the LICENSE file remains current and accurate.
