### PR TITLE
feat(ci): add repository_dispatch to update release PRs via API

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - main
+  repository_dispatch:
+    types: [release-preview]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
     types: [opened, reopened, synchronize]
     branches:
       - main
+  repository_dispatch:
+    types: [release-preview]
 
 permissions:
   contents: write # Required to create tags, creaste releases and update wiki

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+  repository_dispatch:
+    types: [release-preview]
   schedule:
     - cron: "31 7 * * 3"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+  repository_dispatch:
+    types: [release-preview]
 
 permissions:
   contents: read


### PR DESCRIPTION
Implemented repository_dispatch event in multiple GitHub Action workflows to enable triggering updates for release pull requests through the API. This enhancement allows for better automation and management of release processes, ensuring that updates can be applied seamlessly without manual intervention.