### PR TITLE
Ignore *.tftest.hcl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ __tests__/runner/*
 .idea
 .vscode
 *.code-workspace
+# Ignore test
+*.tftest.hcl


### PR DESCRIPTION
This is my first time resolving an issue on GitHub
To avoid uploading the *tftest.hcl file from build assets, we need to add it to .gitignore file.