### PR TITLE
fix: merge wiki imports in `main.ts`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,8 +6,7 @@ import { createTaggedRelease, deleteLegacyReleases, getAllReleases } from './rel
 import { deleteLegacyTags, getAllTags } from './tags';
 import { installTerraformDocs } from './terraform-docs';
 import { getAllTerraformModules, getTerraformChangedModules, getTerraformModulesToRemove } from './terraform-module';
-import { checkoutWiki, updateWiki } from './wiki';
-import { WikiStatus } from './wiki';
+import { WikiStatus, checkoutWiki, updateWiki } from './wiki';
 
 /**
  * The main function for the action.


### PR DESCRIPTION
Detected via SonarCloud: https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=techpivot_terraform-module-releaser&open=AZKWIJOPz5j6aqbDZllw

### Issue Description
'./wiki' imported multiple times.

Imports from the same module should be merged [typescript:S3863](https://sonarcloud.io/organizations/techpivot/rules?open=typescript%3AS3863&rule_key=typescript%3AS3863)

Software qualities impacted: Maintainability