### PR TITLE
fix: prefer nullish coalescing operator

### DIFF
--- a/src/file-util.ts
+++ b/src/file-util.ts
@@ -28,7 +28,7 @@ export function shouldExcludeFile(baseDirectory: string, filePath: string, exclu
  *                                    Defaults to the source directory if not provided.
  */
 export function copyModuleContents(directory: string, tmpDir: string, baseDirectory?: string) {
-  const baseDir = baseDirectory || directory;
+  const baseDir = baseDirectory ?? directory;
 
   // Read the directory contents
   const filesToCopy = fs.readdirSync(directory);


### PR DESCRIPTION
If baseDirectory is provided as an empty string ("") or 0, the || operator would cause baseDir to default to directory, while the ?? operator would still use the empty string or 0 as baseDir.