### PR TITLE
fix: remove unnecessary escape character

### DIFF
--- a/src/terraform-module.ts
+++ b/src/terraform-module.ts
@@ -123,7 +123,7 @@ function getTerraformModuleNameFromRelativePath(terraformDirectory: string): str
     .replace(/(^\/|\/$)/g, '') // Remove leading/trailing slashes
     .replace(/\.+$/, '') // Remove trailing dots
     .replace(/\.\.+/g, '.') // Replace consecutive dots with a single dot
-    .replace(/\-\-+/g, '-') // Replace consecutive hyphens with a single hyphen
+    .replace(/--+/g, '-') // Replace consecutive hyphens with a single hyphen
     .replace(/\s+/g, '') // Remove any remaining whitespace
     .toLowerCase(); // All of our module names will be lowercase
 }


### PR DESCRIPTION
The hyphen "-" does not need to be escaped.