### PR TITLE
feat: add useSSHSourceFormat option to configure source URL format in Wiki documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,4 @@ jobs:
           delete-legacy-tags: false # Note: We don't want to delete tags in this repository
           module-change-exclude-patterns: .gitignore,*.md,*.tftest.hcl,tests/**
           module-asset-exclude-patterns: .gitignore,*.md,*.tftest.hcl,tests/**
+          use-ssh-source-format: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_REPO_CI_TESTING }}
 
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@v4
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v4
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ configuring the following optional input parameters as needed.
 | `disable-branding`               | Controls whether a small branding link to the action's repository is added to PR comments. Recommended to leave enabled to support OSS.                                                                                                                                                                                                                                                              | `false`                                    |
 | `module-change-exclude-patterns` | A comma-separated list of file patterns to exclude from triggering version changes in Terraform modules. Patterns follow glob syntax (e.g., `.gitignore,_.md`) and are relative to each Terraform module directory. Files matching these patterns will not affect version changes. **WARNING**: Avoid excluding '`_.tf`' files, as they are essential for module detection and versioning processes. | `.gitignore, *.md, *.tftest.hcl, tests/**` |
 | `module-asset-exclude-patterns`  | A comma-separated list of file patterns to exclude when bundling a Terraform module for tag/release. Patterns follow glob syntax (e.g., `tests/\*\*`) and are relative to each Terraform module directory. Files matching these patterns will be excluded from the bundled output.                                                                                                                   | `.gitignore, *.md, *.tftest.hcl, tests/**` |
+| `use-ssh-source-format`          | If enabled, all links to source code in generated Wiki documentation will use SSH standard format (e.g., `git::ssh://git@github.com/owner/repo.git`) instead of HTTPS format (`git::https://github.com/owner/repo.git`)                                                                                                                                                                              | `false`                                    |
 
 ### Example Usage with Inputs
 
@@ -217,6 +218,7 @@ jobs:
           wiki-sidebar-changelog-max: 10
           module-change-exclude-patterns: .gitignore,*.md,*.tftest.hcl,tests/**
           module-asset-exclude-patterns: .gitignore,*.md,*.tftest.hcl,tests/**
+          use-ssh-source-format: false
 ```
 
 ## Inspiration

--- a/__mocks__/config.ts
+++ b/__mocks__/config.ts
@@ -24,6 +24,7 @@ const defaultConfig: Config = {
   moduleChangeExcludePatterns: ['.gitignore', '*.md'],
   moduleAssetExcludePatterns: ['tests/**', 'examples/**'],
   githubToken: 'ghp_test_token_2c6912E7710c838347Ae178B4',
+  useSSHSourceFormat: false,
 };
 
 /**
@@ -42,6 +43,7 @@ const validConfigKeys = [
   'moduleChangeExcludePatterns',
   'moduleAssetExcludePatterns',
   'githubToken',
+  'useSSHSourceFormat',
 ] as const;
 
 type ValidConfigKey = (typeof validConfigKeys)[number];

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -117,10 +117,11 @@ describe('config', () => {
       expect(config.githubToken).toBe('ghp_test_token_2c6912E7710c838347Ae178B4');
       expect(config.moduleChangeExcludePatterns).toEqual(['.gitignore', '*.md']);
       expect(config.moduleAssetExcludePatterns).toEqual(['tests/**', 'examples/**']);
+      expect(config.useSSHSourceFormat).toBe(false);
       expect(startGroup).toHaveBeenCalledWith('Initializing Config');
       expect(startGroup).toHaveBeenCalledTimes(1);
       expect(endGroup).toHaveBeenCalledTimes(1);
-      expect(info).toHaveBeenCalledTimes(10);
+      expect(info).toHaveBeenCalledTimes(11);
       expect(vi.mocked(info).mock.calls).toEqual([
         ['Major Keywords: MAJOR CHANGE, BREAKING CHANGE, !'],
         ['Minor Keywords: feat, feature'],
@@ -132,8 +133,8 @@ describe('config', () => {
         ['Wiki Sidebar Changelog Max: 10'],
         ['Module Change Exclude Patterns: .gitignore, *.md'],
         ['Module Asset Exclude Patterns: tests/**, examples/**'],
+        ['Use SSH Source Format: false'],
       ]);
-      expect(info).toHaveBeenCalledTimes(10);
     });
   });
 

--- a/__tests__/helpers/inputs.ts
+++ b/__tests__/helpers/inputs.ts
@@ -21,9 +21,10 @@ export const defaultInputs = {
   'module-change-exclude-patterns': '.gitignore,*.md',
   'module-asset-exclude-patterns': 'tests/**,examples/**',
   github_token: 'ghp_test_token_2c6912E7710c838347Ae178B4',
+  'use-ssh-source-format': 'false',
 };
 export const requiredInputs = Object.keys(defaultInputs);
-export const booleanInputs = ['delete-legacy-tags', 'disable-wiki', 'disable-branding'];
+export const booleanInputs = ['delete-legacy-tags', 'disable-wiki', 'disable-branding', 'use-ssh-source-format'];
 export const booleanConfigKeys: BooleanConfigKeys[] = ['deleteLegacyTags', 'disableWiki', 'disableBranding'];
 
 /**

--- a/__tests__/wiki.test.ts
+++ b/__tests__/wiki.test.ts
@@ -316,4 +316,51 @@ describe('wiki', async () => {
       expect(commitCall?.[1]).toEqual(['commit', '-m', 'PR #456 - Complex PR title\n\nLine 1\nLine 2\nLine 3']);
     });
   });
+
+  describe('formatModuleSource()', () => {
+    beforeEach(() => {
+      context.set({
+        repo: { owner: 'techpivot', repo: 'terraform-module-releaser' },
+        repoUrl: 'https://github.com/techpivot/terraform-module-releaser',
+      });
+    });
+
+    it('should format source URL as HTTPS when useSSHSourceFormat is false', async () => {
+      config.set({ useSSHSourceFormat: false });
+      const files = await generateWikiFiles(terraformModules);
+
+      // Read each generated .md file and verify it contains HTTPS format
+      for (const file of files) {
+        if (file.endsWith('.md')) {
+          const content = readFileSync(file, 'utf8');
+          if (content.includes('source =')) {
+            expect(content).toContain('source = "git::https://github.com/techpivot/terraform-module-releaser.git?ref=');
+            expect(content).not.toContain(
+              'source = "git::ssh://git@github.com/techpivot/terraform-module-releaser.git?ref=',
+            );
+          }
+        }
+      }
+    });
+
+    it('should format source URL as SSH when useSSHSourceFormat is true', async () => {
+      config.set({ useSSHSourceFormat: true });
+      const files = await generateWikiFiles(terraformModules);
+
+      // Read each generated .md file and verify it contains SSH format
+      for (const file of files) {
+        if (file.endsWith('.md')) {
+          const content = readFileSync(file, 'utf8');
+          if (content.includes('source =')) {
+            expect(content).toContain(
+              'source = "git::ssh://git@github.com/techpivot/terraform-module-releaser.git?ref=',
+            );
+            expect(content).not.toContain(
+              'source = "git::https://github.com/techpivot/terraform-module-releaser.git?ref=',
+            );
+          }
+        }
+      }
+    });
+  });
 });

--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,10 @@ inputs:
       The minimatch syntax is used for pattern matching. Files matching these patterns will be excluded from the bundled output.
     required: true
     default: ".gitignore,*.md,*.tftest.hcl,tests/**"
+  use-ssh-source-format:
+    description: If enabled, all links to source code in generated Wiki documentation will use SSH format instead of HTTPS format
+    required: true
+    default: "false"
   github_token:
     description: |
       Required for retrieving pull request metadata, tags, releases, updating PR comments, wiki, and creating tags/releases.

--- a/package.json
+++ b/package.json
@@ -13,13 +13,7 @@
   "bugs": {
     "url": "https://github.com/techpivot/terraform-module-releaser/issues"
   },
-  "keywords": [
-    "terraform",
-    "module",
-    "releaser",
-    "github-action",
-    "monorepo"
-  ],
+  "keywords": ["terraform", "module", "releaser", "github-action", "monorepo"],
   "license": "MIT",
   "exports": {
     ".": "./dist/index.js"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,7 @@
 sonar.organization=techpivot
 sonar.projectKey=terraform-module-releaser
 sonar.projectName=Terraform Module Releaser
+sonar.projectDescription=A GitHub Action for managing Terraform modules in GitHub monorepos, automating versioning, releases, and documentation.
 
 sonar.sourceEncoding=UTF-8
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,6 +71,7 @@ function initializeConfig(): Config {
       githubToken: getInput('github_token', { required: true }),
       moduleChangeExcludePatterns: getArrayInput('module-change-exclude-patterns'),
       moduleAssetExcludePatterns: getArrayInput('module-asset-exclude-patterns'),
+      useSSHSourceFormat: getBooleanInput('use-ssh-source-format', { required: true }),
     };
 
     // Validate that *.tf is not in excludePatterns
@@ -96,6 +97,7 @@ function initializeConfig(): Config {
     info(`Wiki Sidebar Changelog Max: ${configInstance.wikiSidebarChangelogMax}`);
     info(`Module Change Exclude Patterns: ${configInstance.moduleChangeExcludePatterns.join(', ')}`);
     info(`Module Asset Exclude Patterns: ${configInstance.moduleAssetExcludePatterns.join(', ')}`);
+    info(`Use SSH Source Format: ${configInstance.useSSHSourceFormat}`);
 
     return configInstance;
   } finally {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -194,6 +194,18 @@ export interface Config {
    * tests and other non-functional files as needed.
    */
   moduleAssetExcludePatterns: string[];
+
+  /**
+   * If true, the wiki will use the SSH format for the source URL of the repository.
+   * This changes the format of the source URL in the generated wiki documentation to use the SSH format.
+   *
+   * Example:
+   * - SSH format: git::ssh://git@github.com/techpivot/terraform-module-releaser.git
+   * - HTTPS format: git::https://github.com/techpivot/terraform-module-releaser.git
+   *
+   * When set to true, the SSH standard format (non scp variation) will be used. Otherwise, the HTTPS format will be used.
+   */
+  useSSHSourceFormat: boolean;
 }
 
 /**

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -191,6 +191,23 @@ export function getWikiLink(moduleName: string, relative = true): string {
 }
 
 /**
+ * Formats the module source URL based on configuration settings.
+ *
+ * @param repoUrl - The repository URL
+ * @param useSSH - Whether to use SSH format
+ * @returns The formatted source URL for the module
+ */
+function formatModuleSource(repoUrl: string, useSSH: boolean): string {
+  if (useSSH) {
+    // Convert HTTPS URL to SSH format
+    // From: https://github.com/owner/repo
+    // To:   ssh://git@github.com/owner/repo
+    return `ssh://${repoUrl.replace(/^https:\/\/github\.com/, 'git@github.com')}.git`;
+  }
+  return `${repoUrl}.git`;
+}
+
+/**
  * Generates the wiki file associated with the specified Terraform module.
  * Ensures that the directory structure is created if it doesn't exist and handles overwriting
  * the existing wiki file.
@@ -209,12 +226,13 @@ async function generateWikiModule(terraformModule: TerraformModule): Promise<str
   // Generate a module changelog
   const changelog = getModuleReleaseChangelog(terraformModule);
   const tfDocs = await generateTerraformDocs(terraformModule);
+  const moduleSource = formatModuleSource(context.repoUrl, config.useSSHSourceFormat);
   const wikiContent = [
     '# Usage\n',
     'To use this module in your Terraform, refer to the below module example:\n',
     '```hcl',
     `module "${moduleName.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase()}" {`,
-    `  source = "git::${context.repoUrl}.git?ref=${latestTag}"`,
+    `  source = "git::${moduleSource}?ref=${latestTag}"`,
     '\n  # See inputs below for additional required parameters',
     '}',
     '```',


### PR DESCRIPTION
This pull request introduces a new configuration option to use SSH format for source links in generated Wiki documentation, along with several related updates across the codebase. Here are the most important changes:

### Configuration Updates:
* Added `use-ssh-source-format` option to the configuration, allowing users to choose between SSH and HTTPS formats for source links in Wiki documentation (`.github/workflows/ci.yml`, `action.yml`, `src/types/index.ts`, `src/config.ts`). [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR54) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R86-R89) [[3]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R74) [[4]](diffhunk://#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476R197-R208)

### Documentation and Workflow Changes:
* Updated the `README.md` to include the new `use-ssh-source-format` parameter and its description. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R185) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R221)
* Changed the workflow in `.github/workflows/test.yml` to use `SonarQube Scan` instead of `SonarCloud Scan`.

### Code and Test Updates:
* Modified `__mocks__/config.ts` and `__tests__/config.test.ts` to support and test the new `use-ssh-source-format` configuration option. [[1]](diffhunk://#diff-187248407a0f05463e2c3988dba351ca171c374d04035f46627acce11ce7813aR27) [[2]](diffhunk://#diff-187248407a0f05463e2c3988dba351ca171c374d04035f46627acce11ce7813aR46) [[3]](diffhunk://#diff-c15587d03d21623e0b05ac75bc8ecfc1b1b2d581ee1693b2d16156ad8bfaecd2R120)
* Added tests in `__tests__/wiki.test.ts` to ensure correct formatting of source URLs based on the `useSSHSourceFormat` setting.

### Implementation Details:
* Implemented the `formatModuleSource` function in `src/wiki.ts` to format source URLs based on the new configuration setting. [[1]](diffhunk://#diff-f2651f856883600e7a91259f3e7c437e38ab35370a2d9767992d032cd071af85R193-R209) [[2]](diffhunk://#diff-f2651f856883600e7a91259f3e7c437e38ab35370a2d9767992d032cd071af85R229-R235)

These changes collectively enhance the flexibility and configurability of the module by allowing users to specify their preferred source URL format in the generated Wiki documentation.

---

Fixes #136 