### PR TITLE
ci: add GITHUB_TOKEN environment variable for testing in release workflow

### DIFF
--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Run Tests Typescript
         run: npm run test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_REPO_CI_TESTING }}
 
       - name: Update Coverage Badge
         run: npm run coverage

--- a/__tests__/tags.test.ts
+++ b/__tests__/tags.test.ts
@@ -1,11 +1,10 @@
-import { beforeEach } from 'node:test';
 import { config } from '@/mocks/config';
 import { context } from '@/mocks/context';
 import { deleteLegacyTags, getAllTags } from '@/tags';
 import { stubOctokitReturnData } from '@/tests/helpers/octokit';
 import { debug, endGroup, info, startGroup } from '@actions/core';
 import { RequestError } from '@octokit/request-error';
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('tags', () => {
   const url = 'https://api.github.com/repos/techpivot/terraform-module-releaser/tags';

--- a/__tests__/terraform-docs.test.ts
+++ b/__tests__/terraform-docs.test.ts
@@ -184,7 +184,7 @@ describe('terraform-docs', async () => {
       expect(() => installTerraformDocs(terraformDocsVersion)).toThrow('not found: invalid-non-existent-binary');
     });
 
-    afterAll(()  => {
+    afterAll(() => {
       mockWhichSync.mockRestore();
     });
   });


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release-start.yml` file. The change adds an environment variable `GITHUB_TOKEN` for running tests in the Typescript job.

* [`.github/workflows/release-start.yml`](diffhunk://#diff-51a3d404e297cbb3376bce0db5591906a059cc20487af1ec98e23ac00d9af1f5R50-R51): Added `GITHUB_TOKEN` environment variable to the "Run Tests Typescript" job.

This fixes an issue observed when trying to start the release as observed here:
https://github.com/techpivot/terraform-module-releaser/actions/runs/12038037312