### PR TITLE
test: comment out binary removal to prevent async test errors

### DIFF
--- a/__tests__/terraform-docs.test.ts
+++ b/__tests__/terraform-docs.test.ts
@@ -218,8 +218,10 @@ describe('terraform-docs', async () => {
       'terraform-docs',
       'terraform-docs.tar.gz',
       'terraform-docs.zip',
-      join('/usr/local/bin', 'terraform-docs'),
-      join('C:\\Windows\\System32', 'terraform-docs.exe'),
+      // It appears that removing the actual installed binary causes isssues with other async tests
+      // resulting in errors. Thus, we leave the actual installed binaries on the system.
+      // join('/usr/local/bin', 'terraform-docs'),
+      // join('C:\\Windows\\System32', 'terraform-docs.exe'),
     ];
 
     beforeAll(async () => {


### PR DESCRIPTION
This pull request includes a small but significant change to the `__tests__/terraform-docs.test.ts` file. The change involves commenting out the removal of the actual installed binaries to prevent issues with other asynchronous tests.