### PR TITLE
ci: add formatting step to ensure package.json is correctly formatted…

### DIFF
--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -53,6 +53,11 @@ jobs:
       - name: Update Coverage Badge
         run: npm run coverage
 
+      # Ensure that the package.json is formatted correctly as result of the npm version command sorting keys
+      # differently from biome.continue-on-error:
+      - name: Format Fix
+        run: npm run check:fix
+
       - name: Generate Changelog
         uses: actions/github-script@v7
         id: changelog

--- a/package.json
+++ b/package.json
@@ -13,13 +13,7 @@
   "bugs": {
     "url": "https://github.com/techpivot/terraform-module-releaser/issues"
   },
-  "keywords": [
-    "terraform",
-    "module",
-    "releaser",
-    "github-action",
-    "monorepo"
-  ],
+  "keywords": ["terraform", "module", "releaser", "github-action", "monorepo"],
   "license": "MIT",
   "exports": {
     ".": "./dist/index.js"


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release-start.yml` file to ensure the `package.json` file is correctly formatted after the `npm version` command.

* [`.github/workflows/release-start.yml`](diffhunk://#diff-51a3d404e297cbb3376bce0db5591906a059cc20487af1ec98e23ac00d9af1f5R56-R60): Added a new step to run `npm run check:fix` to format the `package.json` file after the `npm version` command.
* Ensure that `package.json` is correctly formatted using Biome