### PR TITLE
fix: sanitize module name for temporary directory creation to avoid invalid characters

### DIFF
--- a/src/releases.ts
+++ b/src/releases.ts
@@ -121,7 +121,9 @@ export async function createTaggedRelease(
       info(`Next tag version: ${nextTag}`);
 
       // Create a temporary working directory
-      const tmpDir = mkdtempSync(join(tmpdir(), moduleName));
+      // Replace '/' with '-' to create a valid directory name
+      const safeName = moduleName.replace(/\//g, '-');
+      const tmpDir = mkdtempSync(join(tmpdir(), `${safeName}-`));
       info(`Created temp directory: ${tmpDir}`);
 
       // Copy the module's contents to the temporary directory, excluding specified patterns


### PR DESCRIPTION
Resolves: https://github.com/techpivot/terraform-module-releaser/issues/153

/cc @apihlak


---

- [x] Testing: Created a separate tag of this to ensure this was working in separate repo.
