### PR TITLE
fix: update commit message format to exclude PR body for wiki commits

### DIFF
--- a/__tests__/wiki.test.ts
+++ b/__tests__/wiki.test.ts
@@ -275,7 +275,7 @@ describe('wiki', async () => {
         'config --local user.name GitHub Actions',
         'config --local user.email 41898282+github-actions[bot]@users.noreply.github.com',
         'add .',
-        'commit -m PR #123 - Test PR title\n\nTest PR body',
+        'commit -m PR #123 - Test PR title',
         'push origin',
       ]);
 
@@ -334,7 +334,7 @@ describe('wiki', async () => {
 
       // Verify commit message format
       const commitCall = vi.mocked(execFileSync).mock.calls.find((call) => call?.[1]?.includes('commit'));
-      expect(commitCall?.[1]).toEqual(['commit', '-m', 'PR #456 - Complex PR title\n\nLine 1\nLine 2\nLine 3']);
+      expect(commitCall?.[1]).toEqual(['commit', '-m', 'PR #456 - Complex PR title']);
     });
   });
 

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -515,8 +515,14 @@ export function commitAndPushWikiChanges(): void {
   startGroup('Committing and pushing changes to wiki');
 
   try {
-    const { prBody, prNumber, prTitle } = context;
-    const commitMessage = `PR #${prNumber} - ${prTitle}\n\n${prBody}`.trim();
+    const { prNumber, prTitle } = context;
+
+    // Note: We originally used the PR title and PR body to create the commit message; however, due to the way
+    // GitHub formats the commits/revision history for the Wiki it's designed to be smaller and thus we use
+    // the PR title for now.
+    // Ref: https://github.com/techpivot/terraform-modules-demo/wiki/aws%E2%88%95s3%E2%80%92bucket%E2%80%92object/_history
+    // Ref: https://github.com/techpivot/terraform-module-releaser/issues/95
+    const commitMessage = `PR #${prNumber} - ${prTitle}`.trim();
     const wikiDirectory = resolve(context.workspaceDir, WIKI_SUBDIRECTORY_NAME);
     const execWikiOpts: ExecSyncOptions = { cwd: wikiDirectory, stdio: 'inherit' };
     const gitPath = which.sync('git');


### PR DESCRIPTION
This pull request includes changes to the commit message format for wiki updates, simplifying the commit messages by removing the PR body. This change aims to make the commit messages more concise and better suited for GitHub's formatting of the wiki revision history.

---

Fixes #95