### PR TITLE
fix: update changelog format to hyperlink PR numbers and handle multiline commit messages

### DIFF
--- a/__tests__/changelog.test.ts
+++ b/__tests__/changelog.test.ts
@@ -55,13 +55,13 @@ describe('changelog', () => {
       const expectedChangelog = [
         '## `module1/v1.0.0` (2024-11-05)',
         '',
-        '- PR #123 - Test PR Title',
+        '- :twisted_rightwards_arrows:**[PR #123](https://github.com/techpivot/terraform-module-releaser/pull/123)** - Test PR Title',
         '- feat: Add new feature',
         '- fix: Fix bug<br>With multiple lines',
         '',
         '## `module2/v2.0.0` (2024-11-05)',
         '',
-        '- PR #123 - Test PR Title',
+        '- :twisted_rightwards_arrows:**[PR #123](https://github.com/techpivot/terraform-module-releaser/pull/123)** - Test PR Title',
         '- Another commit',
       ].join('\n');
 
@@ -85,7 +85,11 @@ describe('changelog', () => {
         },
       ];
 
-      const expectedChangelog = ['## `module2/v2.0.0` (2024-11-05)', '', '- PR #123 - Test PR Title'].join('\n');
+      const expectedChangelog = [
+        '## `module2/v2.0.0` (2024-11-05)',
+        '',
+        '- :twisted_rightwards_arrows:**[PR #123](https://github.com/techpivot/terraform-module-releaser/pull/123)** - Test PR Title',
+      ].join('\n');
 
       expect(getPullRequestChangelog(terraformChangedModules)).toBe(expectedChangelog);
     });
@@ -114,7 +118,7 @@ describe('changelog', () => {
       const expectedChangelog = [
         '## `module1/v1.0.0` (2024-11-05)',
         '',
-        '- PR #123 - Test PR Title',
+        '- :twisted_rightwards_arrows:**[PR #123](https://github.com/techpivot/terraform-module-releaser/pull/123)** - Test PR Title',
         '- Another commit',
       ].join('\n');
 
@@ -145,7 +149,7 @@ describe('changelog', () => {
       const expectedChangelog = [
         '## `1.0.0` (2024-11-05)',
         '',
-        '- [PR #123](https://github.com/techpivot/terraform-module-releaser/pull/123) - Test PR Title',
+        '- :twisted_rightwards_arrows:**[PR #123](https://github.com/techpivot/terraform-module-releaser/pull/123)** - Test PR Title',
         '- feat: Add new feature',
         '- fix: Fix bug<br>With multiple lines',
       ].join('\n');
@@ -161,9 +165,24 @@ describe('changelog', () => {
       const expectedChangelog = [
         '## `1.0.0` (2024-11-05)',
         '',
-        '- [PR #123](https://github.com/techpivot/terraform-module-releaser/pull/123) - Test PR Title',
+        '- :twisted_rightwards_arrows:**[PR #123](https://github.com/techpivot/terraform-module-releaser/pull/123)** - Test PR Title',
         '- feat: Multiple<br>line<br>commit',
         '- fix: Another<br>Multiline',
+      ].join('\n');
+
+      expect(getModuleChangelog(terraformChangedModule)).toBe(expectedChangelog);
+    });
+
+    it('should handle trimming commit messages', () => {
+      const terraformChangedModule = Object.assign(baseTerraformChangedModule, {
+        commitMessages: ['\nfeat: message with new lines\n'],
+      });
+
+      const expectedChangelog = [
+        '## `1.0.0` (2024-11-05)',
+        '',
+        '- :twisted_rightwards_arrows:**[PR #123](https://github.com/techpivot/terraform-module-releaser/pull/123)** - Test PR Title',
+        '- feat: message with new lines',
       ].join('\n');
 
       expect(getModuleChangelog(terraformChangedModule)).toBe(expectedChangelog);

--- a/tf-modules/vpc-endpoint/main.tf
+++ b/tf-modules/vpc-endpoint/main.tf
@@ -1,3 +1,5 @@
+# Noop
+
 locals {
   endpoints = { for k, v in var.endpoints : k => v }
 


### PR DESCRIPTION
This pull request includes changes to improve the formatting and consistency of changelog entries and test cases. The most important changes include updating the changelog format, improving test cases, and refining the handling of commit messages.

This doesn't necessarily fix #31 as intended as I realized there were to many edge cases; but it does clean it up a bit and we can officially close #31 .

Improvements to changelog formatting:

* [`src/changelog.ts`](diffhunk://#diff-0113a86ffacd1a09a00b49cb6ec6fc3617efc44c901da0f0dbd0b0ef9c3dd0caR14-R34): Added PR number, title, and hyperlink to changelog entries for better clarity and consistency. [[1]](diffhunk://#diff-0113a86ffacd1a09a00b49cb6ec6fc3617efc44c901da0f0dbd0b0ef9c3dd0caR14-R34) [[2]](diffhunk://#diff-0113a86ffacd1a09a00b49cb6ec6fc3617efc44c901da0f0dbd0b0ef9c3dd0caR43-R46) [[3]](diffhunk://#diff-0113a86ffacd1a09a00b49cb6ec6fc3617efc44c901da0f0dbd0b0ef9c3dd0caL35-R55) [[4]](diffhunk://#diff-0113a86ffacd1a09a00b49cb6ec6fc3617efc44c901da0f0dbd0b0ef9c3dd0caL62-R71)

Enhancements to test cases:

* [`__tests__/changelog.test.ts`](diffhunk://#diff-cd68fd106df5a77e32fa023b16916e261803ab7a72d885d771503d25eb1675e9L58-R64): Updated expected changelog entries to include PR hyperlinks and added a new test case to handle trimming commit messages. [[1]](diffhunk://#diff-cd68fd106df5a77e32fa023b16916e261803ab7a72d885d771503d25eb1675e9L58-R64) [[2]](diffhunk://#diff-cd68fd106df5a77e32fa023b16916e261803ab7a72d885d771503d25eb1675e9L88-R92) [[3]](diffhunk://#diff-cd68fd106df5a77e32fa023b16916e261803ab7a72d885d771503d25eb1675e9L117-R121) [[4]](diffhunk://#diff-cd68fd106df5a77e32fa023b16916e261803ab7a72d885d771503d25eb1675e9L148-R152) [[5]](diffhunk://#diff-cd68fd106df5a77e32fa023b16916e261803ab7a72d885d771503d25eb1675e9L164-R189)

Refinement of commit message handling:

* [`src/changelog.ts`](diffhunk://#diff-0113a86ffacd1a09a00b49cb6ec6fc3617efc44c901da0f0dbd0b0ef9c3dd0caR14-R34): Normalized commit messages by trimming and replacing newlines with `<br>` tags for better readability in markdown. [[1]](diffhunk://#diff-0113a86ffacd1a09a00b49cb6ec6fc3617efc44c901da0f0dbd0b0ef9c3dd0caR14-R34) [[2]](diffhunk://#diff-0113a86ffacd1a09a00b49cb6ec6fc3617efc44c901da0f0dbd0b0ef9c3dd0caR43-R46) [[3]](diffhunk://#diff-0113a86ffacd1a09a00b49cb6ec6fc3617efc44c901da0f0dbd0b0ef9c3dd0caL35-R55) [[4]](diffhunk://#diff-0113a86ffacd1a09a00b49cb6ec6fc3617efc44c901da0f0dbd0b0ef9c3dd0caL62-R71)

Other minor updates:

* [`__tests__/wiki.test.ts`](diffhunk://#diff-ab0533b52ec32313090aa1c7d9faa0e42b583b1177ead014ef84c2d5e20144f3L158-L175): Simplified the test case for setting the origin URL in the wiki repository and ensured the correct handling of PR information in commit messages. [[1]](diffhunk://#diff-ab0533b52ec32313090aa1c7d9faa0e42b583b1177ead014ef84c2d5e20144f3L158-L175) [[2]](diffhunk://#diff-ab0533b52ec32313090aa1c7d9faa0e42b583b1177ead014ef84c2d5e20144f3L278-R279) [[3]](diffhunk://#diff-ab0533b52ec32313090aa1c7d9faa0e42b583b1177ead014ef84c2d5e20144f3L322-R328)
* [`tf-modules/vpc-endpoint/main.tf`](diffhunk://#diff-a2d4be40936612e37f56fff249d1837e2d3d7d3977d37f97dd4e9bba864c99caR1-R2): Added a no-operation comment for clarity.