### PR TITLE
refactor(changelog): remove unused context variables from changelog functions

### DIFF
--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -49,7 +49,6 @@ function createModuleChangelogEntry(heading: string, commits: string[]): string 
  */
 export function getPullRequestChangelog(terraformChangedModules: TerraformChangedModule[]): string {
   const pullRequestChangelog: string[] = [];
-  const { prNumber, prTitle } = context;
 
   for (const { nextTag, commitMessages } of terraformChangedModules) {
     pullRequestChangelog.push(createModuleChangelogEntry(nextTag, commitMessages));
@@ -65,7 +64,6 @@ export function getPullRequestChangelog(terraformChangedModules: TerraformChange
  * @returns {string} The content of the module's changelog.
  */
 export function getModuleChangelog(terraformChangedModule: TerraformChangedModule): string {
-  const { prNumber, prTitle, repoUrl } = context;
   const { nextTagVersion, commitMessages } = terraformChangedModule;
 
   return createModuleChangelogEntry(nextTagVersion, commitMessages);


### PR DESCRIPTION
This pull request removes unused variables from the `context` object in the `src/changelog.ts` file to clean up the code and improve maintainability. Specifically, it eliminates variables that are no longer required in the `getPullRequestChangelog` and `getModuleChangelog` functions.


- Fixes #203 
- First detected: https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=terraform-module-releaser&open=AZVA3DMAgpwAwn-Dhh5D&tab=code