### PR TITLE
fix: Fix for GHES to allow variations in GitHub Actions bot user id

### DIFF
--- a/__tests__/helpers/octokit.ts
+++ b/__tests__/helpers/octokit.ts
@@ -19,6 +19,7 @@ type EndpointNames = {
   issues: 'createComment' | 'deleteComment' | 'listComments';
   pulls: 'listCommits' | 'listFiles';
   repos: 'getCommit' | 'listTags' | 'listReleases' | 'createRelease' | 'deleteRelease';
+  users: 'getByUsername';
 };
 
 // Type guard that ensures the method name is valid for the given namespace K.
@@ -164,12 +165,26 @@ export function resetMockStore() {
           headers: {},
         },
       },
+      users: {
+        getByUsername: {
+          data: {
+            login: 'github-actions[bot]',
+            id: 41898282,
+            type: 'Bot',
+            site_admin: false,
+          },
+          status: 200,
+          url: 'https://api.github.com/users/github-actions[bot]',
+          headers: {},
+        },
+      },
     },
     implementations: {
       git: {},
       issues: {},
       pulls: {},
       repos: {},
+      users: {},
     },
   };
 }
@@ -301,6 +316,9 @@ export function createDefaultOctokitMock(): OctokitRestApi {
         listReleases: createPaginatedMockImplementation('repos.listReleases', '/releases'),
         createRelease: vi.fn().mockImplementation(() => getMockResponse('repos.createRelease')),
         deleteRelease: vi.fn().mockImplementation(() => getMockResponse('repos.deleteRelease')),
+      },
+      users: {
+        getByUsername: vi.fn().mockImplementation((params) => getMockResponse('users.getByUsername', params)),
       },
     },
     paginate: {

--- a/__tests__/pull-request.test.ts
+++ b/__tests__/pull-request.test.ts
@@ -7,7 +7,6 @@ import { createMockTerraformModule } from '@/tests/helpers/terraform-module';
 import type { GitHubRelease } from '@/types';
 import {
   BRANDING_COMMENT,
-  GITHUB_ACTIONS_BOT_USER_ID,
   PR_RELEASE_MARKER,
   PR_SUMMARY_MARKER,
   WIKI_STATUS,
@@ -55,7 +54,8 @@ describe('pull-request', () => {
       context.useMockOctokit();
     });
 
-    it('should return false when release marker is found in comments from non github-actions user', async () => {
+
+    it('should return true when release marker is found in comments', async () => {
       stubOctokitReturnData('issues.listComments', {
         data: [
           { user: { id: 123 }, body: 'Some comment' },
@@ -63,19 +63,8 @@ describe('pull-request', () => {
           { user: { id: 123 }, body: 'Another comment' },
         ],
       });
-      expect(await hasReleaseComment()).toBe(false);
-    });
-
-    it('should return true when release marker is found in comments from github-actions user', async () => {
-      stubOctokitReturnData('issues.listComments', {
-        data: [
-          { user: { id: 123 }, body: 'Some comment' },
-          { user: { id: GITHUB_ACTIONS_BOT_USER_ID }, body: PR_RELEASE_MARKER },
-          { user: { id: 123 }, body: 'Another comment' },
-        ],
-      });
       expect(await hasReleaseComment()).toBe(true);
-    });
+    })
 
     it('should return false when no release marker is found', async () => {
       stubOctokitReturnData('issues.listComments', {

--- a/__tests__/pull-request.test.ts
+++ b/__tests__/pull-request.test.ts
@@ -5,12 +5,7 @@ import type { TerraformModule } from '@/terraform-module';
 import { stubOctokitImplementation, stubOctokitReturnData } from '@/tests/helpers/octokit';
 import { createMockTerraformModule } from '@/tests/helpers/terraform-module';
 import type { GitHubRelease } from '@/types';
-import {
-  BRANDING_COMMENT,
-  PR_RELEASE_MARKER,
-  PR_SUMMARY_MARKER,
-  WIKI_STATUS,
-} from '@/utils/constants';
+import { BRANDING_COMMENT, PR_RELEASE_MARKER, PR_SUMMARY_MARKER, WIKI_STATUS } from '@/utils/constants';
 import { debug, endGroup, info, startGroup } from '@actions/core';
 import { RequestError } from '@octokit/request-error';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -54,7 +49,6 @@ describe('pull-request', () => {
       context.useMockOctokit();
     });
 
-
     it('should return true when release marker is found in comments', async () => {
       stubOctokitReturnData('issues.listComments', {
         data: [
@@ -64,7 +58,7 @@ describe('pull-request', () => {
         ],
       });
       expect(await hasReleaseComment()).toBe(true);
-    })
+    });
 
     it('should return false when no release marker is found', async () => {
       stubOctokitReturnData('issues.listComments', {

--- a/__tests__/utils/constants.test.ts
+++ b/__tests__/utils/constants.test.ts
@@ -1,8 +1,8 @@
 import {
   BRANDING_COMMENT,
   BRANDING_WIKI,
-  GITHUB_ACTIONS_BOT_EMAIL,
   GITHUB_ACTIONS_BOT_NAME,
+  GITHUB_ACTIONS_BOT_USERNAME,
   PROJECT_URL,
   PR_RELEASE_MARKER,
   PR_SUMMARY_MARKER,
@@ -10,13 +10,13 @@ import {
 } from '@/utils/constants';
 import { describe, expect, it } from 'vitest';
 
-describe('constants', () => {
+describe('utils/constants', () => {
   it('should have the correct GitHub Actions bot name', () => {
     expect(GITHUB_ACTIONS_BOT_NAME).toBe('GitHub Actions');
   });
 
-  it('should have the correct GitHub Actions bot email', () => {
-    expect(GITHUB_ACTIONS_BOT_EMAIL).toBe('41898282+github-actions[bot]@users.noreply.github.com');
+  it('should have the correct GitHub Actions bot username', () => {
+    expect(GITHUB_ACTIONS_BOT_USERNAME).toBe('github-actions[bot]');
   });
 
   it('should have the correct PR summary marker', () => {

--- a/__tests__/utils/github.test.ts
+++ b/__tests__/utils/github.test.ts
@@ -1,0 +1,29 @@
+import { context } from '@/mocks/context';
+import { getGitHubActionsBotEmail } from '@/utils/github';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+describe('utils/github', () => {
+  describe('getGitHubActionsBotEmail - real API queries', () => {
+    beforeAll(async () => {
+      if (!process.env.GITHUB_TOKEN) {
+        throw new Error('GITHUB_TOKEN environment variable must be set for these tests');
+      }
+      await context.useRealOctokit();
+    });
+
+    afterAll(() => {
+      context.useMockOctokit();
+    });
+
+    it('should return the correct email format for GitHub.com public API', async () => {
+      // This test uses the real GitHub API and expects the standard GitHub.com user ID
+      // for the github-actions[bot] user, which is 41898282
+      
+      // Act
+      const result = await getGitHubActionsBotEmail();
+
+      // Assert
+      expect(result).toBe('41898282+github-actions[bot]@users.noreply.github.com');
+    });
+  });
+});

--- a/__tests__/utils/github.test.ts
+++ b/__tests__/utils/github.test.ts
@@ -1,6 +1,6 @@
 import { context } from '@/mocks/context';
 import { getGitHubActionsBotEmail } from '@/utils/github';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 describe('utils/github', () => {
   describe('getGitHubActionsBotEmail - real API queries', () => {
@@ -11,15 +11,10 @@ describe('utils/github', () => {
       await context.useRealOctokit();
     });
 
-    afterAll(() => {
-      context.useMockOctokit();
-    });
-
     it('should return the correct email format for GitHub.com public API', async () => {
       // This test uses the real GitHub API and expects the standard GitHub.com user ID
       // for the github-actions[bot] user, which is 41898282
-      
-      // Act
+
       const result = await getGitHubActionsBotEmail();
 
       // Assert

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,7 +78,7 @@ async function handlePullRequestMergedEvent(
     ensureTerraformDocsConfigDoesNotExist();
     checkoutWiki();
     await generateWikiFiles(terraformModules);
-    commitAndPushWikiChanges();
+    await commitAndPushWikiChanges();
   }
 }
 

--- a/src/pull-request.ts
+++ b/src/pull-request.ts
@@ -3,13 +3,7 @@ import { config } from '@/config';
 import { context } from '@/context';
 import { TerraformModule } from '@/terraform-module';
 import type { CommitDetails, GitHubRelease, WikiStatusResult } from '@/types';
-import {
-  BRANDING_COMMENT,
-  PROJECT_URL,
-  PR_RELEASE_MARKER,
-  PR_SUMMARY_MARKER,
-  WIKI_STATUS,
-} from '@/utils/constants';
+import { BRANDING_COMMENT, PROJECT_URL, PR_RELEASE_MARKER, PR_SUMMARY_MARKER, WIKI_STATUS } from '@/utils/constants';
 
 import { getWikiLink } from '@/wiki';
 import { debug, endGroup, info, startGroup } from '@actions/core';

--- a/src/pull-request.ts
+++ b/src/pull-request.ts
@@ -5,7 +5,6 @@ import { TerraformModule } from '@/terraform-module';
 import type { CommitDetails, GitHubRelease, WikiStatusResult } from '@/types';
 import {
   BRANDING_COMMENT,
-  GITHUB_ACTIONS_BOT_USER_ID,
   PROJECT_URL,
   PR_RELEASE_MARKER,
   PR_SUMMARY_MARKER,
@@ -38,7 +37,7 @@ export async function hasReleaseComment(): Promise<boolean> {
 
     for await (const { data } of iterator) {
       for (const comment of data) {
-        if (comment.user?.id === GITHUB_ACTIONS_BOT_USER_ID && comment.body?.includes(PR_RELEASE_MARKER)) {
+        if (comment.body?.includes(PR_RELEASE_MARKER)) {
           return true;
         }
       }

--- a/src/releases.ts
+++ b/src/releases.ts
@@ -7,8 +7,9 @@ import { config } from '@/config';
 import { context } from '@/context';
 import { TerraformModule } from '@/terraform-module';
 import type { GitHubRelease } from '@/types';
-import { GITHUB_ACTIONS_BOT_EMAIL, GITHUB_ACTIONS_BOT_NAME } from '@/utils/constants';
+import { GITHUB_ACTIONS_BOT_NAME } from '@/utils/constants';
 import { copyModuleContents } from '@/utils/file';
+import { getGitHubActionsBotEmail } from '@/utils/github';
 import { debug, endGroup, info, startGroup } from '@actions/core';
 import type { RestEndpointMethodTypes } from '@octokit/plugin-rest-endpoint-methods';
 import { RequestError } from '@octokit/request-error';
@@ -139,13 +140,14 @@ export async function createTaggedReleases(terraformModules: TerraformModule[]):
       // Git operations: commit the changes and tag the release
       const commitMessage = `${module.getReleaseTag()}\n\n${prTitle}\n\n${prBody}`.trim();
       const gitPath = await which('git');
+      const githubActionsBotEmail = await getGitHubActionsBotEmail();
 
       // Execute git commands in temp directory without inheriting stdio to avoid output pollution
       const gitOpts: ExecSyncOptions = { cwd: tmpDir };
 
       for (const cmd of [
         ['config', '--local', 'user.name', GITHUB_ACTIONS_BOT_NAME],
-        ['config', '--local', 'user.email', GITHUB_ACTIONS_BOT_EMAIL],
+        ['config', '--local', 'user.email', githubActionsBotEmail],
         ['add', '.'],
         ['commit', '-m', commitMessage.trim()],
         ['tag', releaseTag],

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -46,9 +46,8 @@ export const WIKI_HOME_FILENAME = 'Home.md';
 export const WIKI_SIDEBAR_FILENAME = '_Sidebar.md';
 export const WIKI_FOOTER_FILENAME = '_Footer.md';
 
-export const GITHUB_ACTIONS_BOT_USER_ID = 41898282;
 export const GITHUB_ACTIONS_BOT_NAME = 'GitHub Actions';
-export const GITHUB_ACTIONS_BOT_EMAIL = '41898282+github-actions[bot]@users.noreply.github.com';
+export const GITHUB_ACTIONS_BOT_USERNAME = 'github-actions[bot]';
 
 export const PR_SUMMARY_MARKER = '<!-- techpivot/terraform-module-releaser — pr-summary-marker -->';
 export const PR_RELEASE_MARKER = '<!-- techpivot/terraform-module-releaser — release-marker -->';

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -4,16 +4,16 @@ import { GITHUB_ACTIONS_BOT_USERNAME } from '@/utils/constants';
 /**
  * Retrieves the GitHub Actions bot email address dynamically by querying the GitHub API.
  * This function handles both GitHub.com and GitHub Enterprise Server environments.
- * 
+ *
  * The email format follows GitHub's standard: {user_id}+{username}@users.noreply.github.com
- * 
+ *
  * @returns {Promise<string>} The GitHub Actions bot email address
  * @throws {Error} If the API request fails or the user information cannot be retrieved
  */
 export async function getGitHubActionsBotEmail(): Promise<string> {
-    const response = await context.octokit.rest.users.getByUsername({
-      username: GITHUB_ACTIONS_BOT_USERNAME,
-    });
-    
-    return `${response.data.id}+${GITHUB_ACTIONS_BOT_USERNAME}@users.noreply.github.com`;
+  const response = await context.octokit.rest.users.getByUsername({
+    username: GITHUB_ACTIONS_BOT_USERNAME,
+  });
+
+  return `${response.data.id}+${GITHUB_ACTIONS_BOT_USERNAME}@users.noreply.github.com`;
 }

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -1,0 +1,19 @@
+import { context } from '@/context';
+import { GITHUB_ACTIONS_BOT_USERNAME } from '@/utils/constants';
+
+/**
+ * Retrieves the GitHub Actions bot email address dynamically by querying the GitHub API.
+ * This function handles both GitHub.com and GitHub Enterprise Server environments.
+ * 
+ * The email format follows GitHub's standard: {user_id}+{username}@users.noreply.github.com
+ * 
+ * @returns {Promise<string>} The GitHub Actions bot email address
+ * @throws {Error} If the API request fails or the user information cannot be retrieved
+ */
+export async function getGitHubActionsBotEmail(): Promise<string> {
+    const response = await context.octokit.rest.users.getByUsername({
+      username: GITHUB_ACTIONS_BOT_USERNAME,
+    });
+    
+    return `${response.data.id}+${GITHUB_ACTIONS_BOT_USERNAME}@users.noreply.github.com`;
+}

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -583,11 +583,11 @@ export async function commitAndPushWikiChanges(): Promise<void> {
 
     if (status !== null && status.toString().trim() !== '') {
       // There are changes, commit and push
-      const botEmail = await getGitHubActionsBotEmail();
-      
+      const githubActionsBotEmail = await getGitHubActionsBotEmail();
+
       for (const cmd of [
         ['config', '--local', 'user.name', GITHUB_ACTIONS_BOT_NAME],
-        ['config', '--local', 'user.email', botEmail],
+        ['config', '--local', 'user.email', githubActionsBotEmail],
         ['add', '.'],
         ['commit', '-m', commitMessage.trim()],
         ['push', 'origin'],

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -12,7 +12,6 @@ import type { TerraformModule } from '@/terraform-module';
 import type { ExecSyncError, WikiStatusResult } from '@/types';
 import {
   BRANDING_WIKI,
-  GITHUB_ACTIONS_BOT_EMAIL,
   GITHUB_ACTIONS_BOT_NAME,
   PROJECT_URL,
   WIKI_FOOTER_FILENAME,
@@ -22,6 +21,7 @@ import {
   WIKI_TITLE_REPLACEMENTS,
 } from '@/utils/constants';
 import { removeDirectoryContents } from '@/utils/file';
+import { getGitHubActionsBotEmail } from '@/utils/github';
 import { endGroup, info, startGroup } from '@actions/core';
 import pLimit from 'p-limit';
 import which from 'which';
@@ -558,9 +558,9 @@ export async function generateWikiFiles(terraformModules: TerraformModule[]): Pr
  * pushes them to the remote wiki repository. If no changes are detected, it logs a
  * message and exits gracefully without creating a commit.
  *
- * @returns {void}
+ * @returns {Promise<void>}
  */
-export function commitAndPushWikiChanges(): void {
+export async function commitAndPushWikiChanges(): Promise<void> {
   startGroup('Committing and pushing changes to wiki');
 
   try {
@@ -583,9 +583,11 @@ export function commitAndPushWikiChanges(): void {
 
     if (status !== null && status.toString().trim() !== '') {
       // There are changes, commit and push
+      const botEmail = await getGitHubActionsBotEmail();
+      
       for (const cmd of [
         ['config', '--local', 'user.name', GITHUB_ACTIONS_BOT_NAME],
-        ['config', '--local', 'user.email', GITHUB_ACTIONS_BOT_EMAIL],
+        ['config', '--local', 'user.email', botEmail],
         ['add', '.'],
         ['commit', '-m', commitMessage.trim()],
         ['push', 'origin'],


### PR DESCRIPTION
This pull request introduces several changes across the codebase to improve handling of GitHub Actions bot information, refactor constants, enhance test coverage, and ensure asynchronous handling of functions. The most significant updates include replacing hardcoded bot email and ID with dynamic retrieval from the GitHub API, refactoring constants for clarity, and converting several functions to asynchronous operations.

### GitHub Actions Bot Information Updates:
* [`src/utils/github.ts`](diffhunk://#diff-17d4d8c034232c0ebf862f175362bb32f27866d1c0c2e11145c8ea4bce6749a7R1-R19): Added a new function `getGitHubActionsBotEmail` to dynamically retrieve the GitHub Actions bot email address using the GitHub API. This replaces hardcoded values for better adaptability across environments.
* `src/releases.ts` and `src/wiki.ts`: Updated Git configuration commands to use the dynamically retrieved bot email instead of the hardcoded `GITHUB_ACTIONS_BOT_EMAIL`. [[1]](diffhunk://#diff-b6141940aa0947caad5e88ffc5955ac65243ab1b0c21345fc72d360a21614aaeR143-R150) [[2]](diffhunk://#diff-f2651f856883600e7a91259f3e7c437e38ab35370a2d9767992d032cd071af85R586-R590)

### Constants Refactoring:
* [`src/utils/constants.ts`](diffhunk://#diff-e8d0a358ae2fb090c56f00a058050983cc9691b7d3622ddd443170017123e7d9L49-R50): Removed `GITHUB_ACTIONS_BOT_USER_ID` and `GITHUB_ACTIONS_BOT_EMAIL`, replacing them with `GITHUB_ACTIONS_BOT_USERNAME` for consistency and clarity.

### Test Enhancements:
* [`__tests__/helpers/octokit.ts`](diffhunk://#diff-86018dfaff8c9ae3b61fdfb06b905c0d9887c716e036ea17712e5efb90e6ad6bR22): Added support for mocking the `users.getByUsername` endpoint to facilitate testing of the new dynamic bot email retrieval functionality. [[1]](diffhunk://#diff-86018dfaff8c9ae3b61fdfb06b905c0d9887c716e036ea17712e5efb90e6ad6bR22) [[2]](diffhunk://#diff-86018dfaff8c9ae3b61fdfb06b905c0d9887c716e036ea17712e5efb90e6ad6bR168-R187) [[3]](diffhunk://#diff-86018dfaff8c9ae3b61fdfb06b905c0d9887c716e036ea17712e5efb90e6ad6bR320-R322)
* [`__tests__/utils/github.test.ts`](diffhunk://#diff-29ac35a36fcc7b3cbb39c7587c95349913196d1ce9983600c03aac5483b81fc1R1-R24): Added new tests to validate the behavior of the `getGitHubActionsBotEmail` function using real API queries.

### Asynchronous Function Updates:
* `src/wiki.ts`, `src/releases.ts`, and `src/main.ts`: Converted `commitAndPushWikiChanges` and related calls to asynchronous functions for improved reliability and error handling. [[1]](diffhunk://#diff-f2651f856883600e7a91259f3e7c437e38ab35370a2d9767992d032cd071af85L561-R563) [[2]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dL81-R81)

### Simplification of Release Comment Logic:
* [`src/pull-request.ts`](diffhunk://#diff-d1da22882cf874979608625652f25e295abc314c94f3a77ed2c7fe6bfe52bb62L41-R34): Simplified the `hasReleaseComment` function by removing the check for `GITHUB_ACTIONS_BOT_USER_ID`, allowing the function to focus solely on the presence of the release marker.