### PR TITLE
fix: use bearer auth instead of token

### DIFF
--- a/__tests__/helpers/octokit.ts
+++ b/__tests__/helpers/octokit.ts
@@ -358,7 +358,7 @@ export async function createRealOctokit(): Promise<OctokitRestApi> {
   const OctokitWithPaginateAndRest = realOctokit.Octokit.plugin(restEndpointMethods, paginateRest);
 
   return new OctokitWithPaginateAndRest({
-    auth: `token ${process.env.GITHUB_TOKEN}`,
+    auth: `Bearer ${process.env.GITHUB_TOKEN}`,
     userAgent: '[octokit] terraform-module-releaser-ci-test',
   });
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -126,7 +126,7 @@ function initializeContext(): Context {
       repoUrl: `${serverUrl}/${owner}/${repo}`,
       octokit: new OctokitRestApi({
         baseUrl: apiUrl,
-        auth: `token ${config.githubToken}`,
+        auth: `Bearer ${config.githubToken}`,
         userAgent: `[octokit] terraform-module-releaser/${version} (${homepage})`,
       }),
       prNumber: payload.pull_request.number,


### PR DESCRIPTION
On a GHES instance, I had the following error when using the action : 

```
Error: Error checking PR comments: Bad credentials - https://docs.github.com/rest
```

I've tried to also pass a PAT, and error was the same. 

As per Github documentation it seems for most cases we should use Bearer instead of token for auth param.
<img width="750" height="147" alt="Capture d’écran 2025-08-11 à 19 15 49" src="https://github.com/user-attachments/assets/f4ed7965-a04f-4223-ab39-76fe8d716399" />

With this fix I don't have auth error anymore. 
