### PR TITLE
fix: update GITHUB_TOKEN reference for testing prior to release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - main
 
 permissions:
-  contents: write # Required to create tags, creaste releases and update wiki
+  contents: write # Required to create tags, create releases and update wiki
   pull-requests: write # Required to comment on pull requests
 
 jobs:

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run Tests Typescript
         run: npm run test
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_REPO_CI_TESTING }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update Coverage Badge
         run: npm run coverage


### PR DESCRIPTION
This pull request makes minor improvements to the GitHub Actions workflow files by fixing a typo in a comment and updating the environment variable used for authentication in the release workflow.

* Workflow configuration improvements:
  * Fixed a typo in the comment describing the `contents: write` permission in `.github/workflows/ci.yml`.
  * Updated the environment variable for `GITHUB_TOKEN` in the test step of `.github/workflows/release-start.yml` to use `${{ secrets.GITHUB_TOKEN }}` instead of a custom secret.