### PR TITLE
fix: update action output handling for closed events to ensure accurate module release information

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,10 @@ The following outputs are available from this action:
 }
 ```
 
+> **Note**: When using outputs during the `closed` event, the `changed-modules-map` output will show `latestTag` as the
+> previous release version, while `releaseTag` and `releaseType` reflect the new release that was just created. To
+> reference the newly published version, use the value of `releaseTag`.
+
 ## Inspiration
 
 This action was inspired by the blog post

--- a/src/main.ts
+++ b/src/main.ts
@@ -210,13 +210,17 @@ export async function run(): Promise<void> {
     const releasesToDelete = TerraformModule.getReleasesToDelete(allReleases, terraformModules);
     const tagsToDelete = TerraformModule.getTagsToDelete(allTags, terraformModules);
 
+    // Important: Let's set the action outputs prior to performing the closed/merge request release.
+    // This is because the changed modules filters on [module.needsRelease()] which will be false
+    // after the release is created. By setting the outputs here, we ensure they accurately reflect
+    // the modules that were changed and needed release at this point in time.
+    setActionOutputs(terraformModules);
+
     if (context.isPrMergeEvent) {
       await handlePullRequestMergedEvent(config, terraformModules, releasesToDelete, tagsToDelete);
     } else {
       await handlePullRequestEvent(terraformModules, releasesToDelete, tagsToDelete);
     }
-
-    setActionOutputs(terraformModules);
   } catch (error) {
     if (error instanceof Error) {
       setFailed(error.message);


### PR DESCRIPTION
This pull request addresses the accuracy of action outputs during the release process, particularly for the `closed` event. The main improvement ensures that outputs related to changed modules and release tags correctly reflect the state before a release is created, preventing inconsistencies in downstream usage.

**Action output accuracy improvements:**

* Moved the call to `setActionOutputs(terraformModules)` in `src/main.ts` to occur before any release actions, ensuring outputs represent modules that needed release prior to the release being created.

**Documentation updates:**

* Added a note to `README.md` clarifying how the `changed-modules-map` output, `latestTag`, and `releaseTag` behave during the `closed` event, guiding users to reference the correct tag for the newly published version.


Fixes #270 