### PR TITLE
chore: update SonarQube scan action to version 7.0.0 and add guidelines for pinning third-party actions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -99,8 +99,8 @@ mode. Use existing patterns.
 `__tests__/utils/metadata.test.ts` in the same change.
 
 **Always**: For third-party GitHub Actions in workflow `uses:` steps, pin to a full commit SHA and keep an adjacent
-version comment (for example `# vX.Y.Z`). Determine the version by searching **all upstream tags**, selecting the
-latest semantic version, then resolving that tag to its SHA.
+version comment (for example `# vX.Y.Z`). Determine the version by searching **all upstream tags**, selecting the latest
+semantic version, then resolving that tag to its SHA.
 
 **Ask first**: Adding new dependencies. Changing build config. Modifying GitHub Actions workflows.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,6 +98,10 @@ mode. Use existing patterns.
 **Always**: When adding/removing/changing inputs in `action.yml`, update `src/utils/metadata.ts` (`ACTION_INPUTS`) and
 `__tests__/utils/metadata.test.ts` in the same change.
 
+**Always**: For third-party GitHub Actions in workflow `uses:` steps, pin to a full commit SHA and keep an adjacent
+version comment (for example `# vX.Y.Z`). Determine the version by searching **all upstream tags**, selecting the
+latest semantic version, then resolving that tag to its SHA.
+
 **Ask first**: Adding new dependencies. Changing build config. Modifying GitHub Actions workflows.
 
 **Never**: Commit without running lint/tests. Modify `dist/` manually. Bypass TypeScript strict checks. Check in bundle

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,6 @@ jobs:
 
       # Note: SonarQube requires the results from tests to get the coverage report
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@2f77a1ec69fb1d595b06f35ab27e97605bdef703 # v5.3.2
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
This pull request updates project documentation and workflows to improve security and maintainability. The most important changes include adding instructions for pinning third-party GitHub Actions to specific commit SHAs and updating the SonarQube scan action to a newer version.

**Documentation updates:**
* [`.github/copilot-instructions.md`](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R101-R104): Added guidance to always pin third-party GitHub Actions in workflow `uses:` steps to a full commit SHA with an adjacent version comment, and instructions on how to determine the correct SHA.

**Workflow updates:**
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L41-R41): Updated the SonarQube scan GitHub Action to use version 7.0.0 by pinning to its latest commit SHA.


Fixes #386 