### PR TITLE
fix: update CodeQL workflow link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ documentation.</b></sup>
 [1]: https://github.com/techpivot/terraform-module-releaser/releases/latest
 [2]: https://github.com/marketplace/actions/terraform-module-releaser
 [3]: https://github.com/techpivot/terraform-module-releaser/actions/workflows/lint.yml
-[4]: https://github.com/techpivot/terraform-module-releaser/actions/workflows/codeql-analysis.yml
+[4]: https://github.com/techpivot/terraform-module-releaser/actions/workflows/codeql.yml
 [5]: https://sonarcloud.io/summary/new_code?id=terraform-module-releaser
 
 Simplify the management of Terraform modules in your monorepo with this **GitHub Action**. It automates module-specific


### PR DESCRIPTION
This pull request updates a workflow link in the `README.md` to reflect the correct path for the CodeQL workflow. This ensures the documentation points to the current workflow file.

- Documentation update:
  * Updated the CodeQL workflow link in `README.md` from `codeql-analysis.yml` to `codeql.yml` to match the actual workflow filename.