### PR TITLE
fix: update changelog generation step to use new GitHub token syntax

### DIFF
--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -72,9 +72,8 @@ jobs:
       - name: Generate Changelog
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         id: changelog
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_READ_AND_MODELS }}
         with:
+          github-token: ${{ secrets.GH_TOKEN_READ_AND_MODELS }}
           result-encoding: json
           script: |
             const { generateChangelog } = await import('${{ github.workspace }}/scripts/changelog.js');


### PR DESCRIPTION
This pull request updates the way the GitHub token is passed to the `actions/github-script` step in the `.github/workflows/release-start.yml` workflow. Instead of setting the token as an environment variable, it is now passed using the `github-token` input, which is the recommended approach for this action.

Workflow improvements:

* [`.github/workflows/release-start.yml`](diffhunk://#diff-51a3d404e297cbb3376bce0db5591906a059cc20487af1ec98e23ac00d9af1f5L75-R76): Changed from using an environment variable to passing `GH_TOKEN_READ_AND_MODELS` via the `github-token` input for the `actions/github-script` step, aligning with best practices for GitHub Actions.