### PR TITLE
feat(releases): idempotent, self-healing releases with verified tag provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,14 +474,14 @@ jobs:
 
 The following outputs are available from this action:
 
-| Output                 | Type     | Description                                                                                                |
-| ---------------------- | -------- | ---------------------------------------------------------------------------------------------------------- |
-| `changed-module-names` | `string` | JSON array of module names that were changed in the current pull request                                   |
-| `changed-module-paths` | `string` | JSON array of file system paths to the modules that were changed                                           |
-| `changed-modules-map`  | `string` | JSON object mapping module names to their change details including current tag, next tag, and release type |
-| `all-module-names`     | `string` | JSON array of all module names found in the repository                                                     |
-| `all-module-paths`     | `string` | JSON array of file system paths to all modules in the repository                                           |
-| `all-modules-map`      | `string` | JSON object mapping all module names to their details including path, latest tag, and latest tag version   |
+| Output                 | Type     | Description                                                                                                                                  |
+| ---------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `changed-module-names` | `string` | JSON array of module names that were changed in the current pull request                                                                     |
+| `changed-module-paths` | `string` | JSON array of file system paths to the modules that were changed                                                                             |
+| `changed-modules-map`  | `string` | JSON object mapping module names to their change details including current tag, release tag, release type, and (on merge) the `action` taken |
+| `all-module-names`     | `string` | JSON array of all module names found in the repository                                                                                       |
+| `all-module-paths`     | `string` | JSON array of file system paths to all modules in the repository                                                                             |
+| `all-modules-map`      | `string` | JSON object mapping all module names to their details including path, latest tag, and latest tag version                                     |
 
 ### Example Output Structure
 
@@ -494,7 +494,8 @@ The following outputs are available from this action:
       "path": "modules/aws/vpc",
       "latestTag": "aws/vpc/v1.0.0",
       "releaseTag": "aws/vpc/v1.1.0",
-      "releaseType": "minor"
+      "releaseType": "minor",
+      "action": "created"
     }
   },
   "all-module-names": ["aws/s3", "aws/vpc"],
@@ -518,8 +519,34 @@ The following outputs are available from this action:
 ```
 
 > **Note**: When using outputs during the `closed` event, the `changed-modules-map` output will show `latestTag` as the
-> previous release version, while `releaseTag` and `releaseType` reflect the new release that was just created. To
-> reference the newly published version, use the value of `releaseTag`.
+> previous release version, while `releaseTag` reflects the tag that this pull request's release actually resolved to.
+> To reference the newly published version, use the value of `releaseTag`.
+
+#### The `action` field (`closed` event only)
+
+Releases are idempotent and self-healing, so a merge re-run does not always create a new version — it may find the
+module already released, or recover a release onto an existing tag. Each `changed-modules-map` entry therefore carries
+an `action` field on the `closed` event, and `releaseTag` always names a tag that **actually exists**:
+
+| `action`    | Meaning                                                                       | `releaseTag`     |
+| ----------- | ----------------------------------------------------------------------------- | ---------------- |
+| `created`   | A new version was bumped, tagged, and released.                               | the new tag      |
+| `recovered` | A missing release was created for a tag this pull request had already pushed. | the existing tag |
+| `skipped`   | This pull request had already released this module; nothing was created.      | the existing tag |
+| `none`      | Nothing was released for this module on this run.                             | `null`           |
+
+Branch on `action` before treating `releaseTag` as a newly published release — for example, to avoid re-publishing to a
+registry on a workflow re-run:
+
+```yaml
+- name: Publish newly released modules
+  run: |
+    echo '${{ steps.release.outputs.changed-modules-map }}' \
+      | jq -r 'to_entries[] | select(.value.action == "created") | .value.releaseTag'
+```
+
+> The `action` field is only present on the `closed` (merge) event. On `opened`/`synchronize` runs, `releaseTag` remains
+> the version that _would_ be created.
 
 ## Terraform Docs Configuration
 

--- a/__mocks__/context.ts
+++ b/__mocks__/context.ts
@@ -32,6 +32,8 @@ const defaultContext: Context = {
   prBody: 'This is a test pull request body.',
   issueNumber: 1,
   workspaceDir: process.cwd(),
+  baseRef: 'main',
+  mergeCommitSha: 'merge-commit-sha',
   isPrMergeEvent: false,
 };
 
@@ -47,6 +49,8 @@ const validContextKeys = [
   'prBody',
   'issueNumber',
   'workspaceDir',
+  'baseRef',
+  'mergeCommitSha',
   'isPrMergeEvent',
 ] as const;
 
@@ -67,7 +71,12 @@ const contextProxyHandler: ProxyHandler<ContextWithMethods> = {
     const typedKey = key as keyof Context;
     const expectedValue = defaultContext[typedKey];
 
-    if (typeof expectedValue === typeof value || (typedKey === 'octokit' && typeof value === 'object')) {
+    // `mergeCommitSha` is nullable, so `typeof` alone cannot validate it.
+    if (
+      typeof expectedValue === typeof value ||
+      (typedKey === 'octokit' && typeof value === 'object') ||
+      (typedKey === 'mergeCommitSha' && (value === null || typeof value === 'string'))
+    ) {
       // @ts-expect-error - we know the key is valid and value type is correct
       currentContext[typedKey] = value;
       return true;
@@ -132,6 +141,8 @@ const defaultPullRequestPayload = {
     title: 'Test PR',
     body: 'Test PR body',
     merged: false,
+    base: { ref: 'main' },
+    merge_commit_sha: 'abc123merge',
   },
   repository: {
     full_name: 'techpivot/terraform-module-releaser',

--- a/__tests__/changelog.test.ts
+++ b/__tests__/changelog.test.ts
@@ -6,6 +6,7 @@ import {
 import { context } from '@/mocks/context';
 import type { TerraformModule } from '@/terraform-module';
 import { createMockTerraformModule } from '@/tests/helpers/terraform-module';
+import { buildPrMarker, matchesPrMarker } from '@/utils/markers';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('changelog', () => {
@@ -237,6 +238,60 @@ describe('changelog', () => {
       });
 
       expect(getTerraformModuleFullReleaseChangelog(terraformModule)).toBe('Single release content');
+    });
+  });
+
+  describe('marker neutralization (forgery prevention)', () => {
+    it('neutralizes a marker forged in the pull request title', () => {
+      // Without neutralization this release body would carry PR #99's marker, permanently suppressing
+      // pull request #99's own release for this module and defeating the legacy gate.
+      const forged = buildPrMarker(99);
+      context.set({ prNumber: 123, prTitle: `feat: innocent title\n\n${forged}` });
+
+      const module = createMockTerraformModule({
+        directory: '/module',
+        commitMessages: ['feat: something'],
+      });
+      const body = createTerraformModuleChangelog(module);
+
+      expect(matchesPrMarker(body, 99)).toBe(false);
+      expect(body).toContain('&lt;!--');
+    });
+
+    it('neutralizes a marker forged in a commit message body', () => {
+      const forged = buildPrMarker(99);
+      context.set({ prNumber: 123, prTitle: 'Test PR Title' });
+
+      const module = createMockTerraformModule({
+        directory: '/module',
+        commitMessages: [`fix: looks harmless\n\n${forged}`],
+      });
+      const body = createTerraformModuleChangelog(module);
+
+      expect(matchesPrMarker(body, 99)).toBe(false);
+    });
+
+    it('leaves the genuine trailing marker appended by createTaggedReleases matchable', () => {
+      // The action appends its own marker AFTER the changelog, so neutralizing untrusted text must not
+      // interfere with the real tie.
+      context.set({ prNumber: 123, prTitle: `feat: title with ${buildPrMarker(99)}` });
+
+      const module = createMockTerraformModule({ directory: '/module', commitMessages: ['feat: x'] });
+      const releaseBody = `${createTerraformModuleChangelog(module)}\n\n${buildPrMarker(123)}`;
+
+      expect(matchesPrMarker(releaseBody, 123)).toBe(true);
+      expect(matchesPrMarker(releaseBody, 99)).toBe(false);
+    });
+
+    it('leaves ordinary titles and commit messages unchanged', () => {
+      context.set({ prNumber: 123, prTitle: 'feat: a normal title' });
+
+      const module = createMockTerraformModule({ directory: '/module', commitMessages: ['fix: a normal commit'] });
+      const body = createTerraformModuleChangelog(module);
+
+      expect(body).toContain('feat: a normal title');
+      expect(body).toContain('fix: a normal commit');
+      expect(body).not.toContain('&lt;');
     });
   });
 });

--- a/__tests__/context.test.ts
+++ b/__tests__/context.test.ts
@@ -113,8 +113,50 @@ describe('context', () => {
         prBody: 'Test PR body',
         issueNumber: 1323,
         workspaceDir: '/workspace',
+        baseRef: 'main',
+        mergeCommitSha: 'abc123merge',
         isPrMergeEvent: false,
       });
+    });
+
+    it('should expose a null merge commit sha when the payload has none', () => {
+      mockReadFileSync.mockImplementation(() => {
+        return JSON.stringify(
+          createPullRequestMock({
+            pull_request: {
+              merge_commit_sha: null,
+            },
+          }),
+        );
+      });
+
+      expect(getContext().mergeCommitSha).toBeNull();
+    });
+
+    it('should expose the base ref the pull request targets', () => {
+      mockReadFileSync.mockImplementation(() => {
+        return JSON.stringify(
+          createPullRequestMock({
+            pull_request: {
+              base: { ref: 'release/1.x' },
+            },
+          }),
+        );
+      });
+
+      expect(getContext().baseRef).toBe('release/1.x');
+    });
+
+    it('should throw when the payload has no base ref', () => {
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          action: 'opened',
+          pull_request: { number: 1, title: 'T', body: 'B', merged: false },
+          repository: { full_name: 'techpivot/terraform-module-releaser' },
+        }),
+      );
+
+      expect(() => getContext()).toThrow('Event payload did not match expected pull_request event payload');
     });
 
     it('should initialize as merge event', () => {
@@ -206,7 +248,7 @@ describe('context', () => {
       const getterRepo = getContext().repo;
       expect(proxyRepo).toEqual(getterRepo);
       expect(startGroup).toHaveBeenCalledWith('Initializing Context');
-      expect(info).toHaveBeenCalledTimes(11);
+      expect(info).toHaveBeenCalledTimes(13);
 
       // Reset mock call counts/history via mockClear()
       vi.mocked(info).mockClear();

--- a/__tests__/helpers/fake-github.ts
+++ b/__tests__/helpers/fake-github.ts
@@ -1,0 +1,214 @@
+import { TerraformModule } from '@/terraform-module';
+import { stubOctokitImplementation } from '@/tests/helpers/octokit';
+import type { CommitDetails, GitHubRelease, GitHubTag } from '@/types';
+
+/**
+ * A minimal, **stateful** stand-in for the parts of GitHub this action mutates.
+ *
+ * Every unit test in this repository is a single invocation against hand-built fixtures. The whole
+ * point of self-healing releases, however, is what happens on the *second* run — when the tags,
+ * releases, comments and release commits produced by run N become the input to run N+1. That seam is
+ * where the real defects lived (see the B1 regression), and no amount of single-shot fixture testing
+ * reaches it.
+ *
+ * This fake closes that gap in-process. It records:
+ * - **tags** and the **commit message** of the commit each tag points at (the provenance oracle), so
+ *   `git.getCommit` answers truthfully on later runs;
+ * - **releases** and their bodies (where the idempotency marker lives);
+ * - **issue comments**, so post-release comment idempotency is observable.
+ *
+ * The fake git implementation is the important part: `createTaggedReleases` shells out to
+ * `git commit -m <msg>` / `git tag <name>` / `git push origin <name>`, and unless the message written
+ * there is carried forward, provenance cannot be tested at all.
+ */
+export interface FakeRepoState {
+  tags: GitHubTag[];
+  releases: GitHubRelease[];
+  comments: { id: number; node_id: string; body: string; created_at: string; user: { login: string } }[];
+  /** commit sha -> commit message. Populated by the fake `git commit`. */
+  commits: Map<string, string>;
+  /** Directories (relative to the workspace) that contain a Terraform module. */
+  moduleDirectories: string[];
+  /** `compareCommitsWithBasehead` result — flip to 'ahead' to simulate a stale checkout. */
+  compareStatus: 'identical' | 'ahead' | 'behind' | 'diverged';
+  /** Paths that 404 on the base ref (used by the resurrection guard). */
+  missingOnBaseRef: Set<string>;
+}
+
+let seq = 0;
+const nextId = () => ++seq;
+
+/**
+ * Creates a fake repository and wires it into the shared Octokit mock.
+ *
+ * @param {Partial<FakeRepoState>} initial - Seed state (existing tags, releases, comments, modules).
+ * @returns {FakeRepoState} The live state object; assertions read from it directly.
+ */
+export function createFakeRepo(initial: Partial<FakeRepoState> = {}): FakeRepoState {
+  const state: FakeRepoState = {
+    tags: initial.tags ?? [],
+    releases: initial.releases ?? [],
+    comments: initial.comments ?? [],
+    commits: initial.commits ?? new Map(),
+    moduleDirectories: initial.moduleDirectories ?? [],
+    compareStatus: initial.compareStatus ?? 'identical',
+    missingOnBaseRef: initial.missingOnBaseRef ?? new Set(),
+  };
+
+  // Generic so each endpoint's literal `data` type survives instead of widening to `unknown`.
+  const ok = <T>(data: T, status = 200) => ({ data, status, url: 'https://api.github.com/fake', headers: {} });
+
+  // Shape matters: getAllTags() reads `tag.commit.sha`.
+  stubOctokitImplementation('repos.listTags', () =>
+    ok(state.tags.map((tag) => ({ name: tag.name, commit: { sha: tag.commitSHA } }))),
+  );
+  stubOctokitImplementation('repos.listReleases', () =>
+    ok(
+      state.releases.map((release) => ({
+        id: release.id,
+        name: release.title,
+        body: release.body,
+        tag_name: release.tagName,
+      })),
+    ),
+  );
+
+  stubOctokitImplementation('repos.createRelease', (params) => {
+    const p = params as { tag_name: string; name?: string; body?: string };
+    const release: GitHubRelease = {
+      id: nextId(),
+      title: p.name ?? p.tag_name,
+      tagName: p.tag_name,
+      body: p.body ?? '',
+    };
+    state.releases.unshift(release);
+    return ok({ id: release.id, name: release.title, tag_name: release.tagName, body: release.body }, 201);
+  });
+
+  stubOctokitImplementation('repos.deleteRelease', (params) => {
+    const { release_id } = params as { release_id: number };
+    state.releases = state.releases.filter((release) => release.id !== release_id);
+    return ok(undefined, 204);
+  });
+
+  // The provenance oracle: answer with the message recorded by the fake `git commit`.
+  stubOctokitImplementation('git.getCommit', (params) => {
+    const { commit_sha } = params as { commit_sha: string };
+    const message = state.commits.get(commit_sha);
+    if (message === undefined) {
+      throw Object.assign(new Error('Not Found'), { status: 404 });
+    }
+    return ok({ message });
+  });
+
+  stubOctokitImplementation('repos.compareCommitsWithBasehead', () =>
+    ok({ status: state.compareStatus, ahead_by: state.compareStatus === 'identical' ? 0 : 3, behind_by: 0 }),
+  );
+
+  stubOctokitImplementation('repos.getContent', (params) => {
+    const { path } = params as { path: string };
+    if (state.missingOnBaseRef.has(path)) {
+      throw Object.assign(new Error('Not Found'), { status: 404 });
+    }
+    return ok({});
+  });
+
+  stubOctokitImplementation('issues.listComments', () => ok(state.comments));
+  stubOctokitImplementation('issues.createComment', (params) => {
+    const { body } = params as { body: string };
+    const comment = {
+      id: nextId(),
+      node_id: `node-${seq}`,
+      body,
+      created_at: '2026-01-01T00:00:00Z',
+      user: { login: 'github-actions[bot]' },
+    };
+    state.comments.push(comment);
+    return ok({ id: comment.id, html_url: `https://x/#${comment.id}` }, 201);
+  });
+  stubOctokitImplementation('issues.updateComment', (params) => {
+    const { comment_id, body } = params as { comment_id: number; body: string };
+    const comment = state.comments.find((c) => c.id === comment_id);
+    if (comment) {
+      comment.body = body;
+    }
+    return ok({ id: comment_id });
+  });
+  stubOctokitImplementation('issues.deleteComment', (params) => {
+    const { comment_id } = params as { comment_id: number };
+    state.comments = state.comments.filter((c) => c.id !== comment_id);
+    return ok(undefined, 204);
+  });
+
+  return state;
+}
+
+/**
+ * Builds a fake `execFileSync` that emulates just enough git for `createTaggedReleases`.
+ *
+ * Critically it records the message passed to `git commit -m` against the synthetic SHA that
+ * `git rev-parse HEAD` then returns, and associates that SHA with the tag pushed immediately after.
+ * Without this, a tag created by run N carries no recoverable message and provenance on run N+1 could
+ * not be exercised at all.
+ *
+ * @param {FakeRepoState} state - The repository state to mutate.
+ * @returns {(file: string, args?: readonly string[]) => Buffer} A drop-in `execFileSync` replacement.
+ */
+export function createFakeGit(state: FakeRepoState) {
+  let pendingMessage = '';
+  let pendingSha = '';
+
+  return (_file: string, args?: readonly string[]): Buffer => {
+    const argv = Array.isArray(args) ? args : [];
+
+    if (argv[0] === 'commit' && argv[1] === '-m') {
+      pendingMessage = String(argv[2]);
+      pendingSha = `sha-${nextId()}`;
+      state.commits.set(pendingSha, pendingMessage);
+      return Buffer.from('');
+    }
+
+    if (argv[0] === 'tag') {
+      // `git tag <name>` — remember which tag the pending commit belongs to.
+      state.tags.unshift({ name: String(argv[1]), commitSHA: pendingSha });
+      // Keep tags ordered the way TerraformModule expects (semver desc is applied by setTags).
+      return Buffer.from('');
+    }
+
+    if (argv[0] === 'rev-parse') {
+      return Buffer.from(pendingSha);
+    }
+
+    return Buffer.from('');
+  };
+}
+
+/**
+ * Builds Terraform modules the way `parseTerraformModules` would, from the fake state.
+ *
+ * Reuses the real tag/release association logic (`TerraformModule.getTagsForModule` /
+ * `getReleasesForModule`) so module naming, tag matching and semver ordering behave exactly as in
+ * production — only the filesystem walk is replaced.
+ *
+ * @param {FakeRepoState} state - The repository state.
+ * @param {string} workspaceDir - The workspace root.
+ * @param {CommitDetails[]} commits - Commits attributed to the pull request.
+ * @returns {TerraformModule[]} Modules with tags, releases and commits attached.
+ */
+export function buildModules(
+  state: FakeRepoState,
+  workspaceDir: string,
+  commits: CommitDetails[] = [],
+): TerraformModule[] {
+  return state.moduleDirectories.map((relativeDir) => {
+    const module = new TerraformModule(`${workspaceDir}/${relativeDir}`);
+    module.setTags(TerraformModule.getTagsForModule(module.name, state.tags));
+    module.setReleases(TerraformModule.getReleasesForModule(module.name, state.releases));
+    for (const commit of commits) {
+      if (commit.files.some((file) => file.startsWith(`${workspaceDir}/${relativeDir}/`))) {
+        module.addCommit(commit);
+      }
+    }
+    return module;
+  });
+}

--- a/__tests__/helpers/octokit.ts
+++ b/__tests__/helpers/octokit.ts
@@ -15,10 +15,17 @@ type DeepPartial<T> = T extends object
 
 // Names of the supported endpoints across different namespaces (e.g., git, issues, pulls, repos).
 type EndpointNames = {
-  git: 'createTag' | 'deleteRef';
+  git: 'createTag' | 'deleteRef' | 'getCommit';
   issues: 'createComment' | 'deleteComment' | 'listComments' | 'updateComment';
   pulls: 'listCommits' | 'listFiles';
-  repos: 'getCommit' | 'listTags' | 'listReleases' | 'createRelease' | 'deleteRelease';
+  repos:
+    | 'getCommit'
+    | 'listTags'
+    | 'listReleases'
+    | 'createRelease'
+    | 'deleteRelease'
+    | 'compareCommitsWithBasehead'
+    | 'getContent';
   users: 'getByUsername';
 };
 
@@ -87,6 +94,14 @@ export function resetMockStore() {
           url: 'https://api.github.com/repos/techpivot/terraform-module-releaser/git/refs',
           headers: {},
         },
+        getCommit: {
+          // Backs the orphan-tag provenance check. The default carries no marker and does not match the
+          // release-commit shape, so a tag is NOT attributable unless a test stubs it that way.
+          data: { message: 'Test commit message' },
+          status: 200,
+          url: 'https://api.github.com/repos/techpivot/terraform-module-releaser/git/commits',
+          headers: {},
+        },
       },
       issues: {
         createComment: {
@@ -135,9 +150,25 @@ export function resetMockStore() {
       },
       repos: {
         getCommit: {
-          data: { files: [{ filename: 'file1.tf' }] },
+          // Used by getPullRequestCommits for its `files` list. (Orphan-tag provenance reads commit
+          // messages through the lighter Git Data API instead — see `git.getCommit` above.)
+          data: { files: [{ filename: 'file1.tf' }], commit: { message: 'Test commit message' } },
           status: 200,
           url: 'https://api.github.com/repos/techpivot/terraform-module-releaser/commits',
+          headers: {},
+        },
+        compareCommitsWithBasehead: {
+          // Default: the checkout is current, so destructive merge steps are not skipped.
+          data: { status: 'identical', ahead_by: 0, behind_by: 0 },
+          status: 200,
+          url: 'https://api.github.com/repos/techpivot/terraform-module-releaser/compare',
+          headers: {},
+        },
+        getContent: {
+          // Default: the path exists on the base ref (module was not deleted).
+          data: {},
+          status: 200,
+          url: 'https://api.github.com/repos/techpivot/terraform-module-releaser/contents',
           headers: {},
         },
         listTags: {
@@ -304,13 +335,14 @@ export function createDefaultOctokitMock(): OctokitRestApi {
   const mockOctokit = {
     rest: {
       git: {
-        deleteRef: vi.fn().mockImplementation(() => getMockResponse('git.deleteRef')),
-        createTag: vi.fn().mockImplementation(() => getMockResponse('git.createTag')),
+        deleteRef: vi.fn().mockImplementation((params) => getMockResponse('git.deleteRef', params)),
+        createTag: vi.fn().mockImplementation((params) => getMockResponse('git.createTag', params)),
+        getCommit: vi.fn().mockImplementation((params) => getMockResponse('git.getCommit', params)),
       },
       issues: {
-        createComment: vi.fn().mockImplementation(() => getMockResponse('issues.createComment')),
-        deleteComment: vi.fn().mockImplementation(() => getMockResponse('issues.deleteComment')),
-        updateComment: vi.fn().mockImplementation(() => getMockResponse('issues.updateComment')),
+        createComment: vi.fn().mockImplementation((params) => getMockResponse('issues.createComment', params)),
+        deleteComment: vi.fn().mockImplementation((params) => getMockResponse('issues.deleteComment', params)),
+        updateComment: vi.fn().mockImplementation((params) => getMockResponse('issues.updateComment', params)),
         listComments: createPaginatedMockImplementation('issues.listComments', '/issues/comments'),
       },
       pulls: {
@@ -321,8 +353,12 @@ export function createDefaultOctokitMock(): OctokitRestApi {
         getCommit: vi.fn().mockImplementation((params) => getMockResponse('repos.getCommit', params)),
         listTags: createPaginatedMockImplementation('repos.listTags', '/tags'),
         listReleases: createPaginatedMockImplementation('repos.listReleases', '/releases'),
-        createRelease: vi.fn().mockImplementation(() => getMockResponse('repos.createRelease')),
-        deleteRelease: vi.fn().mockImplementation(() => getMockResponse('repos.deleteRelease')),
+        createRelease: vi.fn().mockImplementation((params) => getMockResponse('repos.createRelease', params)),
+        deleteRelease: vi.fn().mockImplementation((params) => getMockResponse('repos.deleteRelease', params)),
+        compareCommitsWithBasehead: vi
+          .fn()
+          .mockImplementation((params) => getMockResponse('repos.compareCommitsWithBasehead', params)),
+        getContent: vi.fn().mockImplementation((params) => getMockResponse('repos.getContent', params)),
       },
       users: {
         getByUsername: vi.fn().mockImplementation((params) => getMockResponse('users.getByUsername', params)),

--- a/__tests__/helpers/terraform-module.ts
+++ b/__tests__/helpers/terraform-module.ts
@@ -1,5 +1,5 @@
 import { TerraformModule } from '@/terraform-module';
-import type { CommitDetails, GitHubRelease, GitHubTag } from '@/types';
+import type { CommitDetails, GitHubRelease, GitHubTag, ReleaseAction, ReleaseOutcome } from '@/types';
 
 /**
  * Helper function to create a GitHubTag from a tag name.
@@ -68,4 +68,35 @@ export function createMockTerraformModule(options: {
   module.setReleases(releases);
 
   return module;
+}
+
+/**
+ * Helper function to build a ReleaseOutcome for testing.
+ *
+ * Defaults to a `created` outcome derived from the module's own state, so most callers only need to
+ * pass the module.
+ *
+ * @param module - The Terraform module the outcome describes
+ * @param overrides - Optional overrides for the action, tag, or release
+ * @returns A ReleaseOutcome suitable for passing to addPostReleaseComment or main's output handling
+ */
+export function createMockReleaseOutcome(
+  module: TerraformModule,
+  overrides: { action?: ReleaseAction; releaseTag?: string; release?: GitHubRelease } = {},
+): ReleaseOutcome {
+  const fallbackTag = overrides.releaseTag ?? module.releases[0]?.tagName ?? (module.getLatestTag() as string);
+  const release: GitHubRelease = overrides.release ??
+    module.releases[0] ?? {
+      id: 1,
+      title: fallbackTag,
+      tagName: fallbackTag,
+      body: 'Mock release body',
+    };
+
+  return {
+    module,
+    action: overrides.action ?? 'created',
+    releaseTag: overrides.releaseTag ?? release.tagName,
+    release,
+  };
 }

--- a/__tests__/integration/self-healing.test.ts
+++ b/__tests__/integration/self-healing.test.ts
@@ -1,0 +1,244 @@
+import { execFileSync } from 'node:child_process';
+import { run } from '@/main';
+import { config } from '@/mocks/config';
+import { context } from '@/mocks/context';
+import { parseTerraformModules } from '@/parser';
+import { type FakeRepoState, buildModules, createFakeGit, createFakeRepo } from '@/tests/helpers/fake-github';
+import type { CommitDetails } from '@/types';
+import { buildPrMarker, matchesPrMarker } from '@/utils/markers';
+import { warning } from '@actions/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * End-to-end convergence tests for the self-healing release model.
+ *
+ * These exercise the REAL `run()`, `createTaggedReleases()`, `addPostReleaseComment()`,
+ * `getTagProvenance()`, marker and freshness code together against a stateful fake GitHub — so one
+ * run's tags, releases, release-commit messages and comments become the next run's input.
+ *
+ * Every other suite in this repository mocks at least one side of that seam and asserts a single
+ * invocation. Multi-run convergence is precisely where the defects were found during live testing
+ * (a re-run silently rewriting the post-release comment; an orphan tag being adopted from the wrong
+ * pull request), so it is worth testing for real rather than by hand-built fixture.
+ */
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return { ...actual, execFileSync: vi.fn() };
+});
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    mkdtempSync: vi.fn(() => '/tmp/fake-module'),
+    cpSync: vi.fn(),
+    readdirSync: vi.fn(() => []),
+    existsSync: vi.fn(() => true),
+    copyFileSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    statSync: vi.fn(() => ({ isDirectory: () => false })),
+    rmSync: vi.fn(),
+  };
+});
+vi.mock('@/parser');
+// The wiki and terraform-docs paths need a network and a binary; they are covered by their own suites.
+vi.mock('@/wiki');
+vi.mock('@/terraform-docs');
+vi.mock('which', () => ({ default: vi.fn(async () => '/usr/bin/git') }));
+
+const WORKSPACE = '/workspace';
+const PR = 1;
+
+describe('integration: self-healing releases (multi-run convergence)', () => {
+  let repo: FakeRepoState;
+
+  /** A pull request commit touching the given module directories. */
+  const commitTouching = (...dirs: string[]): CommitDetails => ({
+    sha: 'c1',
+    message: 'feat: change modules',
+    files: dirs.map((d) => `${WORKSPACE}/${d}/main.tf`),
+  });
+
+  /** Runs the action once, rebuilding modules from the CURRENT fake state (as a fresh run would). */
+  const runAction = async (commits: CommitDetails[]) => {
+    vi.mocked(parseTerraformModules).mockImplementation(() => buildModules(repo, WORKSPACE, commits));
+    await run();
+  };
+
+  const tagNames = () => repo.tags.map((t) => t.name).sort();
+  const releaseTagNames = () => repo.releases.map((r) => r.tagName).sort();
+  const postReleaseComments = () =>
+    repo.comments.filter((c) => c.body.includes('<!-- techpivot/terraform-module-releaser:release:1 -->'));
+  const releasedModulesInComment = () =>
+    (
+      postReleaseComments()
+        .at(-1)
+        ?.body.match(/- \*\*`([^`]+)`\*\*/g) ?? []
+    ).map((m) => m.replace(/- \*\*`|`\*\*/g, ''));
+
+  beforeEach(() => {
+    context.useMockOctokit();
+    context.set({
+      workspaceDir: WORKSPACE,
+      prNumber: PR,
+      issueNumber: PR,
+      prTitle: 'feat: change modules',
+      prBody: 'body',
+      baseRef: 'main',
+      mergeCommitSha: 'merge-sha',
+    });
+    context.isPrMergeEvent = true;
+    config.set({ disableWiki: true, deleteLegacyTags: false, disableBranding: true });
+
+    repo = createFakeRepo({ moduleDirectories: ['modules/alpha', 'modules/beta'] });
+    vi.mocked(execFileSync).mockImplementation(createFakeGit(repo) as never);
+  });
+
+  it('first merge releases every module, stamping the marker in the release body AND the release commit', async () => {
+    await runAction([commitTouching('modules/alpha')]);
+
+    expect(tagNames()).toStrictEqual(['modules/alpha/v1.0.0', 'modules/beta/v1.0.0']);
+    expect(releaseTagNames()).toStrictEqual(['modules/alpha/v1.0.0', 'modules/beta/v1.0.0']);
+
+    for (const release of repo.releases) {
+      expect(matchesPrMarker(release.body, PR)).toBe(true);
+    }
+    for (const tag of repo.tags) {
+      expect(matchesPrMarker(repo.commits.get(tag.commitSHA), PR)).toBe(true);
+    }
+    expect(postReleaseComments()).toHaveLength(1);
+  });
+
+  it('re-running converges: no over-bump, no duplicate release, no duplicate comment', async () => {
+    await runAction([commitTouching('modules/alpha')]);
+    const tagsAfterFirst = tagNames();
+
+    await runAction([commitTouching('modules/alpha')]);
+    await runAction([commitTouching('modules/alpha')]);
+
+    expect(tagNames()).toStrictEqual(tagsAfterFirst);
+    expect(releaseTagNames()).toStrictEqual(tagsAfterFirst);
+    expect(postReleaseComments()).toHaveLength(1);
+  });
+
+  it('regression (B1): a module released only as an INITIAL release stays in the comment on re-run', async () => {
+    // `modules/beta` has no changes in this pull request — it is released purely because it had no
+    // tags. On the re-run it is neither initial nor changed, so it drops out of needsRelease()
+    // entirely. Before the fix the comment was rewritten from the surviving outcomes alone and beta
+    // silently vanished from the pull request's audit trail.
+    await runAction([commitTouching('modules/alpha')]);
+    expect(releasedModulesInComment()).toStrictEqual(['modules/alpha/v1.0.0', 'modules/beta/v1.0.0']);
+
+    await runAction([commitTouching('modules/alpha')]);
+
+    expect(releasedModulesInComment()).toContain('modules/beta/v1.0.0');
+    expect(releasedModulesInComment()).toContain('modules/alpha/v1.0.0');
+  });
+
+  it('self-heals a deleted release at the SAME version, without bumping', async () => {
+    await runAction([commitTouching('modules/alpha')]);
+    repo.releases = repo.releases.filter((r) => r.tagName !== 'modules/alpha/v1.0.0');
+
+    await runAction([commitTouching('modules/alpha')]);
+
+    expect(releaseTagNames()).toContain('modules/alpha/v1.0.0');
+    expect(tagNames()).not.toContain('modules/alpha/v1.1.0');
+    expect(matchesPrMarker(repo.releases.find((r) => r.tagName === 'modules/alpha/v1.0.0')?.body, PR)).toBe(true);
+  });
+
+  it('heals an orphan tag that is no longer the latest (widened step 2)', async () => {
+    await runAction([commitTouching('modules/alpha')]);
+    // Orphan v1.0.0, then let a LATER pull request bump alpha past it.
+    repo.releases = repo.releases.filter((r) => r.tagName !== 'modules/alpha/v1.0.0');
+    context.set({ prNumber: 2, issueNumber: 2 });
+    await runAction([commitTouching('modules/alpha')]);
+    expect(tagNames()).toContain('modules/alpha/v1.1.0');
+
+    // Back to pull request 1: its orphan is no longer latest but is still provably its own.
+    context.set({ prNumber: PR, issueNumber: PR });
+    await runAction([commitTouching('modules/alpha')]);
+
+    expect(releaseTagNames()).toContain('modules/alpha/v1.0.0');
+    expect(tagNames()).not.toContain('modules/alpha/v1.2.0');
+  });
+
+  it('refuses an orphan tag it cannot attribute, and releases its own version instead', async () => {
+    await runAction([commitTouching('modules/alpha')]);
+    // A hand-made tag: higher than everything, no release, and a commit we know nothing about.
+    repo.tags.unshift({ name: 'modules/alpha/v9.0.0', commitSHA: 'handmade-sha' });
+    repo.commits.set('handmade-sha', 'chore: some unrelated hand-made commit');
+    context.set({ prNumber: 3, issueNumber: 3 });
+
+    await runAction([commitTouching('modules/alpha')]);
+
+    // v9.0.0 is left untouched; the pull request's own change is released above it.
+    expect(releaseTagNames()).not.toContain('modules/alpha/v9.0.0');
+    expect(tagNames()).toContain('modules/alpha/v9.1.0');
+  });
+
+  it('refuses an orphan tag carrying a DIFFERENT pull request marker', async () => {
+    await runAction([commitTouching('modules/alpha')]);
+    repo.tags.unshift({ name: 'modules/alpha/v9.0.0', commitSHA: 'foreign-sha' });
+    repo.commits.set('foreign-sha', `modules/alpha/v9.0.0\n\nOther PR\n\nbody\n\n${buildPrMarker(42)}`);
+    context.set({ prNumber: 3, issueNumber: 3 });
+
+    await runAction([commitTouching('modules/alpha')]);
+
+    expect(releaseTagNames()).not.toContain('modules/alpha/v9.0.0');
+    expect(tagNames()).toContain('modules/alpha/v9.1.0');
+  });
+
+  it('neutralizes a forged marker planted in the pull request body', async () => {
+    context.set({ prBody: `Innocent text.\n\n${buildPrMarker(99)}\n\nMore text.` });
+
+    await runAction([commitTouching('modules/alpha')]);
+
+    const tag = repo.tags.find((t) => t.name === 'modules/alpha/v1.0.0');
+    const message = repo.commits.get(tag?.commitSHA ?? '') ?? '';
+    // The forged marker must not be honored; the genuine one must be.
+    expect(matchesPrMarker(message, 99)).toBe(false);
+    expect(matchesPrMarker(message, PR)).toBe(true);
+    expect(message).toContain('&lt;!--');
+  });
+
+  it('legacy gate: skips releasing when a pre-marker post-release comment exists', async () => {
+    repo.comments.push({
+      id: 900,
+      node_id: 'n900',
+      body: '<!-- techpivot/terraform-module-releaser — release-marker -->\n\nreleased by an older version',
+      created_at: '2026-01-01T00:00:00Z',
+      user: { login: 'github-actions[bot]' },
+    });
+
+    await runAction([commitTouching('modules/alpha')]);
+
+    expect(tagNames()).toStrictEqual([]);
+    expect(releaseTagNames()).toStrictEqual([]);
+  });
+
+  it('stale checkout: releases still self-heal but cleanup and wiki are skipped', async () => {
+    config.set({ disableWiki: false, deleteLegacyTags: true });
+    repo.compareStatus = 'ahead';
+
+    await runAction([commitTouching('modules/alpha')]);
+
+    // Releases still happen — self-healing is the point of a re-run...
+    expect(releaseTagNames()).toStrictEqual(['modules/alpha/v1.0.0', 'modules/beta/v1.0.0']);
+
+    // ...but wiki regeneration (destructive: it rewrites the wiki from the stale module list) did not.
+    const { generateWikiFiles, commitAndPushWikiChanges } = await import('@/wiki');
+    expect(vi.mocked(generateWikiFiles)).not.toHaveBeenCalled();
+    expect(vi.mocked(commitAndPushWikiChanges)).not.toHaveBeenCalled();
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining('the checked-out tree is not current'));
+  });
+
+  it('stale checkout: withholds an initial-release module that no longer exists on the base branch', async () => {
+    repo.compareStatus = 'ahead';
+    repo.missingOnBaseRef.add('modules/beta');
+
+    await runAction([commitTouching('modules/alpha')]);
+
+    expect(tagNames()).toStrictEqual(['modules/alpha/v1.0.0']);
+    expect(tagNames()).not.toContain('modules/beta/v1.0.0');
+  });
+});

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -2,16 +2,19 @@ import { run } from '@/main';
 import { config } from '@/mocks/config';
 import { context } from '@/mocks/context';
 import { parseTerraformModules } from '@/parser';
-import { addPostReleaseComment, addReleasePlanComment, getPullRequestCommits, hasReleaseComment } from '@/pull-request';
+import { addPostReleaseComment, addReleasePlanComment, getPullRequestCommits } from '@/pull-request';
 import { createTaggedReleases, deleteReleases, getAllReleases } from '@/releases';
 import { deleteTags, getAllTags } from '@/tags';
 import { installTerraformDocs } from '@/terraform-docs';
 import { TerraformModule } from '@/terraform-module';
-import { createMockTerraformModule } from '@/tests/helpers/terraform-module';
+import { stubOctokitReturnData } from '@/tests/helpers/octokit';
+import { createMockReleaseOutcome, createMockTerraformModule } from '@/tests/helpers/terraform-module';
 import type { GitHubRelease } from '@/types';
 import { WIKI_STATUS } from '@/utils/constants';
+import { buildPrMarker } from '@/utils/markers';
 import { checkoutWiki, commitAndPushWikiChanges, generateWikiFiles, getWikiStatus } from '@/wiki';
-import { info, setFailed, setOutput } from '@actions/core';
+import { info, setFailed, setOutput, warning } from '@actions/core';
+import { RequestError } from '@octokit/request-error';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock most dependencies that are tested elsewhere
@@ -65,7 +68,6 @@ describe('main', () => {
     config.deleteLegacyTags = true;
 
     // Reset mocks with default values
-    vi.mocked(hasReleaseComment).mockResolvedValue(false);
     vi.mocked(getPullRequestCommits).mockResolvedValue([]);
     vi.mocked(getAllTags).mockResolvedValue([]);
     vi.mocked(getAllReleases).mockResolvedValue([]);
@@ -77,17 +79,23 @@ describe('main', () => {
     vi.mocked(generateWikiFiles).mockResolvedValue({ updatedFiles: [], moduleErrors: new Map() });
   });
 
-  it('should exit early if release comment exists', async () => {
-    vi.mocked(hasReleaseComment).mockResolvedValue(true);
+  it('should not short-circuit on a merge event; idempotency is handled during release creation', async () => {
+    // The early-exit based on an existing release comment was removed in favor of per-module
+    // self-healing in createTaggedReleases. The run always performs its read work and delegates
+    // idempotency to release creation rather than exiting early.
+    context.isPrMergeEvent = true;
+    vi.mocked(parseTerraformModules).mockReturnValue([mockTerraformModule]);
+    vi.mocked(createTaggedReleases).mockResolvedValue([createMockReleaseOutcome(mockTerraformModule)]);
 
     await run();
 
-    expect(info).toHaveBeenCalledWith('Release comment found. Exiting.');
-    expect(setOutput).not.toHaveBeenCalled();
+    expect(getPullRequestCommits).toHaveBeenCalled();
+    expect(createTaggedReleases).toHaveBeenCalledWith([mockTerraformModule]);
+    expect(setOutput).toHaveBeenCalled();
   });
 
   it('should handle errors', async () => {
-    vi.mocked(hasReleaseComment).mockRejectedValue(new Error('Test error'));
+    vi.mocked(getPullRequestCommits).mockRejectedValue(new Error('Test error'));
 
     await run();
 
@@ -110,9 +118,8 @@ describe('main', () => {
   });
 
   it('should call checkoutWiki when wiki is enabled during merge event', async () => {
-    vi.mocked(hasReleaseComment).mockResolvedValue(false);
     vi.mocked(parseTerraformModules).mockReturnValue([mockTerraformModule]);
-    vi.mocked(createTaggedReleases).mockResolvedValue([mockTerraformModule]); // Mock the release creation
+    vi.mocked(createTaggedReleases).mockResolvedValue([createMockReleaseOutcome(mockTerraformModule)]); // Mock the release creation
     context.isPrMergeEvent = true; // Changed to merge event
     config.disableWiki = false;
 
@@ -122,9 +129,8 @@ describe('main', () => {
   });
 
   it('should not call checkoutWiki when wiki is disabled', async () => {
-    vi.mocked(hasReleaseComment).mockResolvedValue(false);
     vi.mocked(parseTerraformModules).mockReturnValue([mockTerraformModule]);
-    vi.mocked(createTaggedReleases).mockResolvedValue([mockTerraformModule]);
+    vi.mocked(createTaggedReleases).mockResolvedValue([createMockReleaseOutcome(mockTerraformModule)]);
     context.isPrMergeEvent = true; // Set to merge event so checkoutWiki logic is evaluated
     config.disableWiki = true;
 
@@ -223,7 +229,6 @@ describe('main', () => {
   describe('non-merge event handling', () => {
     beforeEach(() => {
       context.isPrMergeEvent = false;
-      vi.mocked(hasReleaseComment).mockResolvedValue(false);
       vi.mocked(parseTerraformModules).mockReturnValue([mockTerraformModule]);
       vi.mocked(TerraformModule.getReleasesToDelete).mockReturnValue([]);
       vi.mocked(TerraformModule.getTagsToDelete).mockReturnValue([]);
@@ -284,9 +289,8 @@ describe('main', () => {
     beforeEach(() => {
       context.isPrMergeEvent = true;
 
-      vi.mocked(hasReleaseComment).mockResolvedValue(false);
       vi.mocked(parseTerraformModules).mockReturnValue([mockTerraformModule]);
-      vi.mocked(createTaggedReleases).mockResolvedValue([mockTerraformModule]);
+      vi.mocked(createTaggedReleases).mockResolvedValue([createMockReleaseOutcome(mockTerraformModule)]);
     });
 
     it('should handle merge event with wiki enabled', async () => {
@@ -295,7 +299,9 @@ describe('main', () => {
       await run();
 
       expect(createTaggedReleases).toHaveBeenCalledWith([mockTerraformModule]);
-      expect(addPostReleaseComment).toHaveBeenCalledWith([mockTerraformModule]);
+      expect(addPostReleaseComment).toHaveBeenCalledWith([
+        expect.objectContaining({ module: mockTerraformModule, action: 'created' }),
+      ]);
       expect(deleteReleases).toHaveBeenCalledWith([]);
       expect(deleteTags).toHaveBeenCalledWith([]);
       expect(installTerraformDocs).toHaveBeenCalledWith(config.terraformDocsVersion);
@@ -313,7 +319,9 @@ describe('main', () => {
       await run();
 
       expect(createTaggedReleases).toHaveBeenCalledWith([mockTerraformModule]);
-      expect(addPostReleaseComment).toHaveBeenCalledWith([mockTerraformModule]);
+      expect(addPostReleaseComment).toHaveBeenCalledWith([
+        expect.objectContaining({ module: mockTerraformModule, action: 'created' }),
+      ]);
       expect(deleteReleases).toHaveBeenCalledWith([]);
       expect(deleteTags).toHaveBeenCalledWith([]);
       expect(installTerraformDocs).not.toHaveBeenCalled();
@@ -359,7 +367,9 @@ describe('main', () => {
       await run();
 
       expect(createTaggedReleases).toHaveBeenCalledWith([mockTerraformModule]);
-      expect(addPostReleaseComment).toHaveBeenCalledWith([mockTerraformModule]);
+      expect(addPostReleaseComment).toHaveBeenCalledWith([
+        expect.objectContaining({ module: mockTerraformModule, action: 'created' }),
+      ]);
       expect(deleteReleases).not.toHaveBeenCalled();
       expect(deleteTags).not.toHaveBeenCalled();
       expect(info).toHaveBeenCalledWith('Deletion of legacy tags/releases is disabled. Skipping.');
@@ -375,7 +385,7 @@ describe('main', () => {
 
       vi.mocked(TerraformModule.getReleasesToDelete).mockReturnValue(mockReleasesToDelete);
       vi.mocked(TerraformModule.getTagsToDelete).mockReturnValue(mockTagsToDelete);
-      vi.mocked(createTaggedReleases).mockResolvedValue([mockTerraformModule]);
+      vi.mocked(createTaggedReleases).mockResolvedValue([createMockReleaseOutcome(mockTerraformModule)]);
 
       await run();
 
@@ -386,7 +396,9 @@ describe('main', () => {
 
       // Verify correct arguments
       expect(createTaggedReleasesMock).toHaveBeenCalledWith([mockTerraformModule]);
-      expect(addPostReleaseCommentMock).toHaveBeenCalledWith([mockTerraformModule]);
+      expect(addPostReleaseCommentMock).toHaveBeenCalledWith([
+        expect.objectContaining({ module: mockTerraformModule, action: 'created' }),
+      ]);
       expect(deleteReleasesMock).toHaveBeenCalledWith(mockReleasesToDelete);
       expect(deleteTagsMock).toHaveBeenCalledWith(mockTagsToDelete);
 
@@ -400,6 +412,294 @@ describe('main', () => {
 
       // Should still set outputs
       expect(setOutput).toHaveBeenCalled();
+    });
+  });
+
+  describe('stale checkout guard (merge event)', () => {
+    beforeEach(() => {
+      context.isPrMergeEvent = true;
+      context.useMockOctokit();
+      context.set({ workspaceDir: '/workspace', baseRef: 'main', mergeCommitSha: 'merge-sha' });
+      vi.mocked(parseTerraformModules).mockReturnValue([mockTerraformModule]);
+      vi.mocked(createTaggedReleases).mockResolvedValue([createMockReleaseOutcome(mockTerraformModule)]);
+      vi.spyOn(TerraformModule, 'getReleasesToDelete').mockReturnValue([
+        { id: 9, title: 'modules/gone/v1.0.0', body: '', tagName: 'modules/gone/v1.0.0' },
+      ]);
+      vi.spyOn(TerraformModule, 'getTagsToDelete').mockReturnValue(['modules/gone/v1.0.0']);
+    });
+
+    it('skips cleanup and wiki regeneration when the base branch has advanced past the merge commit', async () => {
+      // Re-running an older merged pull request restores a stale tree; the modules added since are
+      // absent from it, so cleanup would delete their tags/releases and the wiki rewrite would drop
+      // their pages. Releases must still run (they self-heal); the destructive steps must not.
+      stubOctokitReturnData('repos.compareCommitsWithBasehead', {
+        data: { status: 'ahead', ahead_by: 7, behind_by: 0 },
+      });
+
+      await run();
+
+      expect(createTaggedReleases).toHaveBeenCalled();
+      expect(addPostReleaseComment).toHaveBeenCalled();
+      expect(deleteReleases).not.toHaveBeenCalled();
+      expect(deleteTags).not.toHaveBeenCalled();
+      expect(installTerraformDocs).not.toHaveBeenCalled();
+      expect(checkoutWiki).not.toHaveBeenCalled();
+      expect(generateWikiFiles).not.toHaveBeenCalled();
+      expect(commitAndPushWikiChanges).not.toHaveBeenCalled();
+      expect(warning).toHaveBeenCalledWith(expect.stringContaining('the checked-out tree is not current'));
+    });
+
+    it('performs cleanup and wiki regeneration when the checkout is current', async () => {
+      // Guards against the freshness check being over-eager and disabling normal merge behavior.
+      stubOctokitReturnData('repos.compareCommitsWithBasehead', {
+        data: { status: 'identical', ahead_by: 0, behind_by: 0 },
+      });
+
+      await run();
+
+      expect(deleteReleases).toHaveBeenCalled();
+      expect(deleteTags).toHaveBeenCalled();
+      expect(generateWikiFiles).toHaveBeenCalled();
+      expect(commitAndPushWikiChanges).toHaveBeenCalled();
+    });
+
+    it('treats an errored freshness check as current (fails open)', async () => {
+      vi.mocked(context.octokit.rest.repos.compareCommitsWithBasehead).mockRejectedValueOnce(
+        new RequestError('compare boom', 500, {
+          request: { method: 'GET', url: '', headers: {} },
+          response: { status: 500, url: '', headers: {}, data: {} },
+        }),
+      );
+
+      await run();
+
+      expect(deleteReleases).toHaveBeenCalled();
+      expect(generateWikiFiles).toHaveBeenCalled();
+    });
+  });
+
+  describe('resurrection guard (stale checkout)', () => {
+    const deletedModule = createMockTerraformModule({
+      directory: '/workspace/modules/deleted-module',
+      commitMessages: ['feat: originally added here'],
+    });
+
+    beforeEach(() => {
+      context.isPrMergeEvent = true;
+      context.useMockOctokit();
+      context.set({ workspaceDir: '/workspace', baseRef: 'main', mergeCommitSha: 'merge-sha' });
+      // Stale checkout: the base branch has moved on.
+      stubOctokitReturnData('repos.compareCommitsWithBasehead', {
+        data: { status: 'ahead', ahead_by: 5, behind_by: 0 },
+      });
+      vi.mocked(createTaggedReleases).mockResolvedValue([]);
+    });
+
+    it('withholds an initial-release module that no longer exists on the base branch', async () => {
+      // The module was deleted by a later pull request (its tags were cleaned up then), so on a stale
+      // checkout it reappears with no tags and looks brand new.
+      vi.mocked(parseTerraformModules).mockReturnValue([deletedModule]);
+      vi.mocked(context.octokit.rest.repos.getContent).mockRejectedValueOnce(
+        new RequestError('Not Found', 404, {
+          request: { method: 'GET', url: '', headers: {} },
+          response: { status: 404, url: '', headers: {}, data: {} },
+        }),
+      );
+
+      await run();
+
+      expect(context.octokit.rest.repos.getContent).toHaveBeenCalledWith(
+        expect.objectContaining({ path: 'modules/deleted-module', ref: 'main' }),
+      );
+      expect(createTaggedReleases).toHaveBeenCalledWith([]);
+      expect(warning).toHaveBeenCalledWith(expect.stringContaining('resurrecting a deleted module'));
+    });
+
+    it('still releases an initial-release module that does exist on the base branch', async () => {
+      // A racing merge: pull request A added the module and B merged first. The module is present at
+      // the base tip, so it must still be released.
+      vi.mocked(parseTerraformModules).mockReturnValue([deletedModule]);
+
+      await run();
+
+      expect(createTaggedReleases).toHaveBeenCalledWith([deletedModule]);
+    });
+
+    it('does not check existence for modules that already have tags', async () => {
+      // Only an initial release can resurrect a deleted module; anything with tags is left alone.
+      vi.mocked(parseTerraformModules).mockReturnValue([mockTerraformModule]);
+
+      await run();
+
+      expect(context.octokit.rest.repos.getContent).not.toHaveBeenCalled();
+      expect(createTaggedReleases).toHaveBeenCalledWith([mockTerraformModule]);
+    });
+  });
+
+  describe('action outputs reflect what was actually released', () => {
+    beforeEach(() => {
+      context.isPrMergeEvent = true;
+      context.useMockOctokit();
+      context.set({ workspaceDir: '/workspace', baseRef: 'main', mergeCommitSha: 'merge-sha' });
+      vi.mocked(parseTerraformModules).mockReturnValue([mockTerraformModule]);
+      vi.spyOn(TerraformModule, 'getModulesNeedingRelease').mockReturnValue([mockTerraformModule]);
+    });
+
+    const lastChangedModulesMap = () => {
+      const calls = vi.mocked(setOutput).mock.calls.filter(([name]) => name === 'changed-modules-map');
+      return calls.at(-1)?.[1] as Record<string, { releaseTag: string | null; action?: string }>;
+    };
+
+    it('reports the existing tag and action "skipped" when the module was already released', async () => {
+      vi.mocked(createTaggedReleases).mockResolvedValue([
+        createMockReleaseOutcome(mockTerraformModule, {
+          action: 'skipped',
+          releaseTag: 'modules/test-module/v1.0.0',
+        }),
+      ]);
+
+      await run();
+
+      expect(lastChangedModulesMap()['modules/test-module']).toMatchObject({
+        releaseTag: 'modules/test-module/v1.0.0',
+        action: 'skipped',
+      });
+    });
+
+    it('reports the healed tag and action "recovered"', async () => {
+      vi.mocked(createTaggedReleases).mockResolvedValue([
+        createMockReleaseOutcome(mockTerraformModule, {
+          action: 'recovered',
+          releaseTag: 'modules/test-module/v1.0.0',
+        }),
+      ]);
+
+      await run();
+
+      expect(lastChangedModulesMap()['modules/test-module']).toMatchObject({
+        releaseTag: 'modules/test-module/v1.0.0',
+        action: 'recovered',
+      });
+    });
+
+    it('reports a null releaseTag and action "none" when nothing was released for the module', async () => {
+      // e.g. the legacy gate skipped this pull request entirely.
+      vi.mocked(createTaggedReleases).mockResolvedValue([]);
+
+      await run();
+
+      expect(lastChangedModulesMap()['modules/test-module']).toMatchObject({
+        releaseTag: null,
+        action: 'none',
+      });
+    });
+
+    it('leaves the non-merge path outputs untouched (no action field)', async () => {
+      context.isPrMergeEvent = false;
+
+      await run();
+
+      expect(lastChangedModulesMap()['modules/test-module']).not.toHaveProperty('action');
+    });
+  });
+
+  describe('post-release comment fidelity across re-runs (regression: B1)', () => {
+    // Found by live testing. On a re-run, createTaggedReleases only sees modules that still
+    // needsRelease(). A module released solely because it was an INITIAL release has a tag afterwards,
+    // so it drops out entirely — and rendering the comment from this run's outcomes alone silently
+    // deleted it from the pull request's audit trail, degrading further on every subsequent re-run.
+    const prMarker = buildPrMarker(1);
+
+    // Released by THIS pull request on an earlier run; no longer needs a release.
+    const priorModule = createMockTerraformModule({
+      directory: '/workspace/modules/prior-module',
+      tags: ['modules/prior-module/v1.0.0'],
+      releases: [
+        {
+          id: 50,
+          title: 'modules/prior-module/v1.0.0',
+          tagName: 'modules/prior-module/v1.0.0',
+          body: `notes\n\n${prMarker}`,
+        },
+      ],
+    });
+
+    // Released by a DIFFERENT pull request; must never be attributed to this one.
+    const foreignModule = createMockTerraformModule({
+      directory: '/workspace/modules/foreign-module',
+      tags: ['modules/foreign-module/v3.0.0'],
+      releases: [
+        {
+          id: 51,
+          title: 'modules/foreign-module/v3.0.0',
+          tagName: 'modules/foreign-module/v3.0.0',
+          body: `notes\n\n${buildPrMarker(2)}`,
+        },
+      ],
+    });
+
+    beforeEach(() => {
+      context.isPrMergeEvent = true;
+      context.useMockOctokit();
+      context.set({ workspaceDir: '/workspace', baseRef: 'main', mergeCommitSha: 'merge-sha' });
+    });
+
+    it('still lists a module this pull request released earlier, even when it is no longer processed', async () => {
+      vi.mocked(parseTerraformModules).mockReturnValue([priorModule, mockTerraformModule, foreignModule]);
+      // Only mockTerraformModule is processed on this re-run; it is skipped (already released).
+      vi.mocked(createTaggedReleases).mockResolvedValue([
+        createMockReleaseOutcome(mockTerraformModule, { action: 'skipped' }),
+      ]);
+
+      await run();
+
+      const reported = vi.mocked(addPostReleaseComment).mock.calls[0][0];
+      const names = reported.map((outcome) => outcome.module.name);
+
+      expect(names).toContain('modules/prior-module');
+      expect(names).toContain('modules/test-module');
+      // A release carrying another pull request's marker must NOT be claimed.
+      expect(names).not.toContain('modules/foreign-module');
+
+      const recovered = reported.find((outcome) => outcome.module.name === 'modules/prior-module');
+      expect(recovered).toMatchObject({ action: 'skipped', releaseTag: 'modules/prior-module/v1.0.0' });
+    });
+
+    it('does not duplicate a module that was processed this run', async () => {
+      vi.mocked(parseTerraformModules).mockReturnValue([priorModule]);
+      vi.mocked(createTaggedReleases).mockResolvedValue([createMockReleaseOutcome(priorModule, { action: 'skipped' })]);
+
+      await run();
+
+      const reported = vi.mocked(addPostReleaseComment).mock.calls[0][0];
+      expect(reported.filter((outcome) => outcome.module.name === 'modules/prior-module')).toHaveLength(1);
+    });
+
+    it('reports nothing extra when no prior release carries this pull request marker', async () => {
+      vi.mocked(parseTerraformModules).mockReturnValue([foreignModule]);
+      vi.mocked(createTaggedReleases).mockResolvedValue([]);
+
+      await run();
+
+      expect(vi.mocked(addPostReleaseComment).mock.calls[0][0]).toStrictEqual([]);
+    });
+
+    it('includes the recovered module in the re-emitted outputs map', async () => {
+      vi.mocked(parseTerraformModules).mockReturnValue([priorModule]);
+      vi.spyOn(TerraformModule, 'getModulesNeedingRelease').mockReturnValue([priorModule]);
+      vi.mocked(createTaggedReleases).mockResolvedValue([]);
+
+      await run();
+
+      const calls = vi.mocked(setOutput).mock.calls.filter(([name]) => name === 'changed-modules-map');
+      const finalMap = calls.at(-1)?.[1] as Record<string, { releaseTag: string | null; action?: string }>;
+
+      // Without the fix this would be action 'none' with a null releaseTag, contradicting the release
+      // that demonstrably exists and carries this pull request's marker.
+      expect(finalMap['modules/prior-module']).toMatchObject({
+        releaseTag: 'modules/prior-module/v1.0.0',
+        action: 'skipped',
+      });
     });
   });
 });

--- a/__tests__/pull-request.test.ts
+++ b/__tests__/pull-request.test.ts
@@ -1,113 +1,84 @@
 import { config } from '@/mocks/config';
 import { context } from '@/mocks/context';
-import { addPostReleaseComment, addReleasePlanComment, getPullRequestCommits, hasReleaseComment } from '@/pull-request';
+import {
+  addPostReleaseComment,
+  addReleasePlanComment,
+  getPullRequestCommits,
+  hasLegacyPostReleaseComment,
+} from '@/pull-request';
 import type { TerraformModule } from '@/terraform-module';
 import { stubOctokitImplementation, stubOctokitReturnData } from '@/tests/helpers/octokit';
-import { createMockTerraformModule } from '@/tests/helpers/terraform-module';
-import type { GitHubRelease } from '@/types';
-import { BRANDING_COMMENT, PR_RELEASE_MARKER, PR_SUMMARY_MARKER, WIKI_STATUS } from '@/utils/constants';
+import { createMockReleaseOutcome, createMockTerraformModule } from '@/tests/helpers/terraform-module';
+import type { GitHubRelease, ReleaseOutcome } from '@/types';
+import {
+  BRANDING_COMMENT,
+  LEGACY_PR_RELEASE_COMMENT_MARKER,
+  PR_RELEASE_COMMENT_MARKER,
+  PR_SUMMARY_MARKER,
+  WIKI_STATUS,
+} from '@/utils/constants';
 import { debug, endGroup, info, startGroup, warning } from '@actions/core';
 import { RequestError } from '@octokit/request-error';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('pull-request', () => {
-  describe('hasReleaseComment() - real API queries', () => {
-    beforeAll(async () => {
-      if (!process.env.GITHUB_TOKEN) {
-        throw new Error('GITHUB_TOKEN environment variable must be set for these tests');
-      }
-      await context.useRealOctokit();
-    });
-
-    it('should return false for PR #111 (no release comment)', async () => {
-      context.set({ prNumber: 111, issueNumber: 111 });
-      expect(await hasReleaseComment()).toBe(false);
-    });
-
-    it('should return true for PR #8 (release comment)', async () => {
-      context.set({ repo: { owner: 'techpivot', repo: 'terraform-modules-demo' }, prNumber: 8, issueNumber: 8 });
-      expect(await hasReleaseComment()).toBe(true);
-    });
-
-    it('should return false for PR #1 (release comment - non github-actions)', async () => {
-      context.set({ repo: { owner: 'techpivot', repo: 'terraform-modules-demo' }, prNumber: 1, issueNumber: 1 });
-      expect(await hasReleaseComment()).toBe(false);
-    });
-
-    it('should handle 401 error gracefully', async () => {
-      // Temporarily clear token to force 401
-      vi.stubEnv('GITHUB_TOKEN', '');
-      await context.useRealOctokit(); // Initializes a new Octokit using the empty GITHUB_TOKEN
-      await expect(hasReleaseComment()).rejects.toThrow(
-        'Error checking PR comments: Bad credentials - https://docs.github.com/rest',
-      );
-    });
-  });
-
-  describe('hasReleaseComment()', () => {
-    beforeAll(() => {
+  describe('hasLegacyPostReleaseComment()', () => {
+    beforeEach(() => {
       context.useMockOctokit();
     });
 
-    it('should return true when release marker is found in comments', async () => {
+    it('returns true when a legacy (pre-marker-scheme) release comment is present', async () => {
       stubOctokitReturnData('issues.listComments', {
         data: [
-          { user: { id: 123 }, body: 'Some comment' },
-          { user: { id: 123 }, body: PR_RELEASE_MARKER },
-          { user: { id: 123 }, body: 'Another comment' },
+          { id: 1, body: 'Some comment' },
+          { id: 2, body: `${LEGACY_PR_RELEASE_COMMENT_MARKER}\nThe following modules have been released:` },
         ],
       });
-      expect(await hasReleaseComment()).toBe(true);
+      expect(await hasLegacyPostReleaseComment()).toBe(true);
     });
 
-    it('should return false when no release marker is found', async () => {
+    it('returns false when only the current (versioned) release marker is present', async () => {
       stubOctokitReturnData('issues.listComments', {
-        data: [
-          { user: { id: 4444 }, body: 'Some comment' },
-          { user: { id: 234234 }, body: 'Another comment' },
-        ],
+        data: [{ id: 1, body: `${PR_RELEASE_COMMENT_MARKER}\nThe following modules have been released:` }],
       });
-      expect(await hasReleaseComment()).toBe(false);
+      expect(await hasLegacyPostReleaseComment()).toBe(false);
     });
 
-    it('should handle empty comments array', async () => {
+    it('returns false when there are no release comments', async () => {
       stubOctokitReturnData('issues.listComments', { data: [] });
-      expect(await hasReleaseComment()).toBe(false);
+      expect(await hasLegacyPostReleaseComment()).toBe(false);
     });
 
-    it('should handle 403 errors', async () => {
-      const errorMessage = 'Permissions error testing';
+    it('fails closed (throws) when listing comments fails', async () => {
+      // A transient failure must never be reported as "not legacy": that is indistinguishable from a
+      // genuine absence and would let a legacy pull request over-bump and double-release. Failing is
+      // cheap because the re-run is idempotent.
       vi.mocked(context.octokit.rest.issues.listComments).mockRejectedValueOnce(
-        new RequestError(errorMessage, 403, {
+        new RequestError('boom', 500, {
+          request: { method: 'GET', url: '', headers: {} },
+          response: { status: 500, url: '', headers: {}, data: {} },
+        }),
+      );
+      await expect(hasLegacyPostReleaseComment()).rejects.toThrow('Failed to check for a legacy release comment: boom');
+
+      // Non-Error branch (String(error))
+      vi.mocked(context.octokit.rest.issues.listComments).mockRejectedValueOnce('string failure');
+      await expect(hasLegacyPostReleaseComment()).rejects.toThrow(
+        'Failed to check for a legacy release comment: string failure',
+      );
+    });
+
+    it('wraps a 403 with actionable permissions remediation', async () => {
+      vi.mocked(context.octokit.rest.issues.listComments).mockRejectedValueOnce(
+        new RequestError('Resource not accessible by integration', 403, {
           request: { method: 'GET', url: '', headers: {} },
           response: { status: 403, url: '', headers: {}, data: {} },
         }),
       );
-      await expect(hasReleaseComment()).rejects.toThrow(
-        `Unable to read and write pull requests due to insufficient permissions. Ensure the workflow permissions.pull-requests is set to "write".\n${errorMessage}`,
+
+      await expect(hasLegacyPostReleaseComment()).rejects.toThrow(
+        'Unable to read and write pull requests due to insufficient permissions',
       );
-    });
-
-    it('should handle request errors', async () => {
-      const errorMessage = 'Generic error testing';
-
-      vi.mocked(context.octokit.rest.issues.listComments).mockRejectedValueOnce(
-        new RequestError(errorMessage, 410, {
-          request: { method: 'GET', url: '', headers: {} },
-          response: { status: 410, url: '', headers: {}, data: {} },
-        }),
-      );
-      await expect(hasReleaseComment()).rejects.toThrow(`Error checking PR comments: ${errorMessage}`);
-
-      vi.mocked(context.octokit.rest.issues.listComments).mockRejectedValueOnce(errorMessage);
-
-      try {
-        await hasReleaseComment();
-      } catch (error) {
-        expect(error instanceof Error).toBe(true);
-        expect((error as Error).message).toBe(`Error checking PR comments: ${errorMessage}`);
-        expect((error as Error).cause).toBe(errorMessage);
-      }
     });
   });
 
@@ -1043,6 +1014,8 @@ describe('pull-request', () => {
       }),
     ];
 
+    const releasedOutcomes: ReleaseOutcome[] = releasedModules.map((module) => createMockReleaseOutcome(module));
+
     beforeEach(() => {
       context.useMockOctokit();
       vi.clearAllMocks();
@@ -1060,11 +1033,11 @@ describe('pull-request', () => {
         data: { id: 1, html_url: 'https://github.com/org/repo/pull/1#issuecomment-1' },
       });
 
-      await addPostReleaseComment(releasedModules);
+      await addPostReleaseComment(releasedOutcomes);
 
       expect(context.octokit.rest.issues.createComment).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: expect.stringContaining(PR_RELEASE_MARKER),
+          body: expect.stringContaining(PR_RELEASE_COMMENT_MARKER),
         }),
       );
       expect(context.octokit.rest.issues.createComment).toHaveBeenCalledWith(
@@ -1085,7 +1058,7 @@ describe('pull-request', () => {
         data: { id: 1, html_url: 'https://github.com/org/repo/pull/1#issuecomment-1' },
       });
 
-      await addPostReleaseComment(releasedModules);
+      await addPostReleaseComment(releasedOutcomes);
 
       expect(context.octokit.rest.issues.createComment).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1100,7 +1073,7 @@ describe('pull-request', () => {
         data: { id: 1, html_url: 'https://github.com/org/repo/pull/1#issuecomment-1' },
       });
 
-      await addPostReleaseComment(releasedModules);
+      await addPostReleaseComment(releasedOutcomes);
 
       expect(context.octokit.rest.issues.createComment).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1115,7 +1088,7 @@ describe('pull-request', () => {
         data: { id: 1, html_url: 'https://github.com/org/repo/pull/1#issuecomment-1' },
       });
 
-      await addPostReleaseComment(releasedModules);
+      await addPostReleaseComment(releasedOutcomes);
 
       expect(context.octokit.rest.issues.createComment).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1130,7 +1103,7 @@ describe('pull-request', () => {
         data: { id: 1, html_url: 'https://github.com/org/repo/pull/1#issuecomment-1' },
       });
 
-      await addPostReleaseComment(releasedModules);
+      await addPostReleaseComment(releasedOutcomes);
 
       expect(context.octokit.rest.issues.createComment).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -1148,7 +1121,7 @@ describe('pull-request', () => {
         }),
       );
 
-      await expect(addPostReleaseComment(releasedModules)).rejects.toThrow(
+      await expect(addPostReleaseComment(releasedOutcomes)).rejects.toThrow(
         'Failed to create a comment on the pull request',
       );
     });
@@ -1162,7 +1135,7 @@ describe('pull-request', () => {
       });
 
       try {
-        await addPostReleaseComment(releasedModules);
+        await addPostReleaseComment(releasedOutcomes);
       } catch (error) {
         expect(error instanceof Error).toBe(true);
         expect((error as Error).message).toBe(expectedErrorString);
@@ -1174,12 +1147,217 @@ describe('pull-request', () => {
       });
 
       try {
-        await addPostReleaseComment(releasedModules);
+        await addPostReleaseComment(releasedOutcomes);
       } catch (error) {
         expect(error instanceof Error).toBe(true);
         expect((error as Error).message).toBe(expectedErrorString);
         expect((error as Error).cause instanceof RequestError).toBe(false);
       }
+    });
+
+    it('updates the existing post-release comment in place on a re-run instead of creating a duplicate', async () => {
+      config.set({ disableWiki: false, disableBranding: false });
+      stubOctokitReturnData('issues.listComments', {
+        data: [{ id: 77, body: `${PR_RELEASE_COMMENT_MARKER}\nstale body` }],
+      });
+
+      await addPostReleaseComment(releasedOutcomes);
+
+      expect(context.octokit.rest.issues.updateComment).toHaveBeenCalledWith(
+        expect.objectContaining({ comment_id: 77, body: expect.stringContaining(PR_RELEASE_COMMENT_MARKER) }),
+      );
+      expect(context.octokit.rest.issues.createComment).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op (no create, no edit) when the existing comment already matches', async () => {
+      config.set({ disableWiki: false, disableBranding: false });
+
+      // First run creates the comment; capture the exact body it produced.
+      stubOctokitReturnData('issues.createComment', { data: { id: 100, html_url: 'https://x/#100' } });
+      await addPostReleaseComment(releasedOutcomes);
+      const createdBody = vi.mocked(context.octokit.rest.issues.createComment).mock.calls[0][0]?.body ?? '';
+
+      // Re-run with an identical existing comment -> nothing to do.
+      stubOctokitReturnData('issues.listComments', { data: [{ id: 100, body: createdBody }] });
+      vi.mocked(context.octokit.rest.issues.createComment).mockClear();
+      vi.mocked(context.octokit.rest.issues.updateComment).mockClear();
+
+      await addPostReleaseComment(releasedOutcomes);
+
+      expect(context.octokit.rest.issues.createComment).not.toHaveBeenCalled();
+      expect(context.octokit.rest.issues.updateComment).not.toHaveBeenCalled();
+    });
+
+    it('consolidates duplicate post-release comments, updating the most recent and deleting the rest', async () => {
+      config.set({ disableWiki: false, disableBranding: false });
+      stubOctokitReturnData('issues.listComments', {
+        data: [
+          { id: 5, body: `${PR_RELEASE_COMMENT_MARKER}\nfirst` },
+          { id: 9, body: `${PR_RELEASE_COMMENT_MARKER}\nsecond` },
+        ],
+      });
+
+      await addPostReleaseComment(releasedOutcomes);
+
+      expect(context.octokit.rest.issues.updateComment).toHaveBeenCalledWith(
+        expect.objectContaining({ comment_id: 9 }),
+      );
+      expect(context.octokit.rest.issues.deleteComment).toHaveBeenCalledWith(
+        expect.objectContaining({ comment_id: 5 }),
+      );
+      expect(context.octokit.rest.issues.createComment).not.toHaveBeenCalled();
+    });
+
+    it('warns and continues when deleting a duplicate post-release comment fails', async () => {
+      config.set({ disableWiki: false, disableBranding: false });
+      stubOctokitReturnData('issues.listComments', {
+        data: [
+          { id: 5, body: `${PR_RELEASE_COMMENT_MARKER}\nfirst` },
+          { id: 9, body: `${PR_RELEASE_COMMENT_MARKER}\nsecond` },
+        ],
+      });
+      // Error branch (error.message): deletion failure during consolidation is best-effort and must not fail the merge.
+      vi.mocked(context.octokit.rest.issues.deleteComment).mockRejectedValueOnce(
+        new RequestError('delete boom', 500, {
+          request: { method: 'GET', url: '', headers: {} },
+          response: { status: 500, url: '', headers: {}, data: {} },
+        }),
+      );
+      await expect(addPostReleaseComment(releasedOutcomes)).resolves.toBeUndefined();
+
+      // Non-Error branch (String(error)).
+      vi.mocked(context.octokit.rest.issues.deleteComment).mockRejectedValueOnce('delete failure string');
+      await expect(addPostReleaseComment(releasedOutcomes)).resolves.toBeUndefined();
+
+      expect(context.octokit.rest.issues.updateComment).toHaveBeenCalledWith(
+        expect.objectContaining({ comment_id: 9 }),
+      );
+      expect(context.octokit.rest.issues.deleteComment).toHaveBeenCalledWith(
+        expect.objectContaining({ comment_id: 5 }),
+      );
+      expect(warning).toHaveBeenCalled();
+    });
+
+    it('reports the release attributed to THIS pull request, not the module’s highest release', async () => {
+      // A later pull request has since bumped this module to v1.2.0. Reporting `releases[0]` would
+      // rewrite this pull request's own comment to cite that other release — and would keep doing so on
+      // every re-run, because the body would never converge.
+      const module = createMockTerraformModule({
+        directory: '/module-shared',
+        releases: [
+          { id: 22, title: 'module-shared/v1.2.0', body: 'other PR notes', tagName: 'module-shared/v1.2.0' },
+          { id: 11, title: 'module-shared/v1.1.0', body: 'our notes', tagName: 'module-shared/v1.1.0' },
+        ],
+      });
+      // Sanity check: the module's highest release really is the other pull request's.
+      expect(module.releases[0].tagName).toBe('module-shared/v1.2.0');
+
+      stubOctokitReturnData('issues.createComment', { data: { id: 1, html_url: 'https://x/#1' } });
+
+      await addPostReleaseComment([
+        createMockReleaseOutcome(module, {
+          action: 'skipped',
+          release: { id: 11, title: 'module-shared/v1.1.0', body: 'our notes', tagName: 'module-shared/v1.1.0' },
+        }),
+      ]);
+
+      const body = vi.mocked(context.octokit.rest.issues.createComment).mock.calls[0][0]?.body ?? '';
+      expect(body).toContain('module-shared/v1.1.0');
+      expect(body).not.toContain('module-shared/v1.2.0');
+    });
+
+    it('falls back to creating a comment (and warns) when listing existing comments fails', async () => {
+      stubOctokitReturnData('issues.createComment', { data: { id: 1, html_url: 'https://x/#1' } });
+
+      // Error branch (error.message)
+      vi.mocked(context.octokit.rest.issues.listComments).mockRejectedValueOnce(
+        new RequestError('list boom', 500, {
+          request: { method: 'GET', url: '', headers: {} },
+          response: { status: 500, url: '', headers: {}, data: {} },
+        }),
+      );
+      await addPostReleaseComment(releasedOutcomes);
+
+      // Non-Error branch (String(error))
+      vi.mocked(context.octokit.rest.issues.listComments).mockRejectedValueOnce('list failure string');
+      await addPostReleaseComment(releasedOutcomes);
+
+      expect(warning).toHaveBeenCalled();
+      expect(context.octokit.rest.issues.createComment).toHaveBeenCalled();
+    });
+  });
+
+  describe('pull request comment pagination', () => {
+    beforeEach(() => {
+      context.useMockOctokit();
+      vi.clearAllMocks();
+    });
+
+    /** Builds `count` filler comments with an optional marked comment injected at `markedIndex`. */
+    const buildComments = (count: number, markedIndex: number, marker: string) =>
+      Array.from({ length: count }, (_, i) => ({
+        id: i + 1,
+        node_id: `node-${i + 1}`,
+        body: i === markedIndex ? `${marker}\nmarked` : `filler comment ${i + 1}`,
+        created_at: '2026-01-01T00:00:00Z',
+      }));
+
+    it('requests 100 comments per page rather than the API default of 30', async () => {
+      stubOctokitReturnData('issues.listComments', { data: buildComments(5, 0, LEGACY_PR_RELEASE_COMMENT_MARKER) });
+
+      await hasLegacyPostReleaseComment();
+
+      expect(context.octokit.rest.issues.listComments).toHaveBeenCalledWith(expect.objectContaining({ per_page: 100 }));
+    });
+
+    it('tolerates comments with a null body', async () => {
+      // The REST API returns `body: null` for some comments (e.g. those with only an attachment). The
+      // generated Octokit types model it as `string | undefined`, so the cast is needed to reproduce
+      // what the API actually sends.
+      stubOctokitReturnData('issues.listComments', {
+        data: [
+          { id: 1, node_id: 'n1', body: null as unknown as string, created_at: '2026-01-01T00:00:00Z' },
+          { id: 2, node_id: 'n2', body: LEGACY_PR_RELEASE_COMMENT_MARKER, created_at: '2026-01-01T00:00:00Z' },
+        ],
+      });
+
+      await expect(hasLegacyPostReleaseComment()).resolves.toBe(true);
+    });
+
+    it('finds a legacy marker that lives beyond the first page', async () => {
+      // 250 comments: the legacy marker sits on page 3. An unpaginated read would miss it and the
+      // legacy pull request would double-release.
+      stubOctokitReturnData('issues.listComments', { data: buildComments(250, 240, LEGACY_PR_RELEASE_COMMENT_MARKER) });
+
+      await expect(hasLegacyPostReleaseComment()).resolves.toBe(true);
+    });
+
+    it('prunes an older release plan comment that lives beyond the first page', async () => {
+      // Regression: addReleasePlanComment used to read only the first page, so on a busy pull request
+      // stale Release Plan comments accumulated forever.
+      stubOctokitReturnData('issues.listComments', { data: buildComments(150, 10, PR_SUMMARY_MARKER) });
+      stubOctokitReturnData('issues.createComment', {
+        data: { id: 9999, html_url: 'https://x/#9999' },
+      });
+
+      await addReleasePlanComment([], [], [], { status: WIKI_STATUS.SUCCESS });
+
+      expect(context.octokit.rest.issues.deleteComment).toHaveBeenCalledWith(
+        expect.objectContaining({ comment_id: 11 }),
+      );
+    });
+
+    it('minimizes an existing release plan comment found beyond the first page', async () => {
+      config.set({ hideNoChangesPrComment: true });
+      stubOctokitReturnData('issues.listComments', { data: buildComments(150, 120, PR_SUMMARY_MARKER) });
+
+      await addReleasePlanComment([], [], [], { status: WIKI_STATUS.SUCCESS });
+
+      expect(context.octokit.rest.issues.updateComment).toHaveBeenCalledWith(
+        expect.objectContaining({ comment_id: 121 }),
+      );
+      expect(context.octokit.graphql).toHaveBeenCalledWith(expect.anything(), { id: 'node-121' });
+      expect(context.octokit.rest.issues.createComment).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/releases.test.ts
+++ b/__tests__/releases.test.ts
@@ -5,16 +5,22 @@ import { config } from '@/mocks/config';
 import { context } from '@/mocks/context';
 import { createTaggedReleases, deleteReleases, getAllReleases } from '@/releases';
 import { TerraformModule } from '@/terraform-module';
-import { stubOctokitReturnData } from '@/tests/helpers/octokit';
+import { stubOctokitImplementation, stubOctokitReturnData } from '@/tests/helpers/octokit';
 import { createMockTerraformModule } from '@/tests/helpers/terraform-module';
 import type { GitHubRelease } from '@/types';
-import { debug, endGroup, info, startGroup } from '@actions/core';
+import { LEGACY_PR_RELEASE_COMMENT_MARKER, PR_RELEASE_COMMENT_MARKER } from '@/utils/constants';
+import { buildPrMarker, matchesPrMarker } from '@/utils/markers';
+import { debug, endGroup, info, startGroup, warning } from '@actions/core';
 import { RequestError } from '@octokit/request-error';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('node:child_process', () => ({
-  execFileSync: vi.fn(),
-}));
+// Mock only execFileSync (used by createTaggedReleases and spied on below); keep the real module so that
+// transitively-loaded modules (src/pull-request.ts -> src/wiki.ts -> src/terraform-docs.ts, which does
+// `promisify(execFile)` at load time) still resolve their child_process imports.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return { ...actual, execFileSync: vi.fn() };
+});
 vi.mock('node:fs', () => ({
   existsSync: vi.fn(),
   copyFileSync: vi.fn(),
@@ -355,7 +361,8 @@ describe('releases', () => {
 
       expect(mockTerraformModule.needsRelease()).toBe(true);
       const releasedModules = await createTaggedReleases([mockTerraformModule]);
-      expect(releasedModules).toStrictEqual([mockTerraformModule]);
+      expect(releasedModules).toHaveLength(1);
+      expect(releasedModules[0]).toMatchObject({ module: mockTerraformModule, action: 'created' });
       expect(mockTerraformModule.setReleases).toHaveBeenCalledWith([
         {
           id: mockRelease.data.id,
@@ -428,7 +435,8 @@ describe('releases', () => {
       const originalTags = mockTerraformModule.tags;
 
       const releasedModules = await createTaggedReleases([mockTerraformModule]);
-      expect(releasedModules).toStrictEqual([mockTerraformModule]);
+      expect(releasedModules).toHaveLength(1);
+      expect(releasedModules[0]).toMatchObject({ module: mockTerraformModule, action: 'created' });
 
       // Verify that the setReleases was called
       expect(mockTerraformModule.setReleases).toHaveBeenCalledOnce();
@@ -467,7 +475,8 @@ describe('releases', () => {
       stubOctokitReturnData('repos.createRelease', mockRelease);
 
       const releasedModules = await createTaggedReleases([mockTerraformModule]);
-      expect(releasedModules).toStrictEqual([mockTerraformModule]);
+      expect(releasedModules).toHaveLength(1);
+      expect(releasedModules[0]).toMatchObject({ module: mockTerraformModule, action: 'created' });
 
       // Verify that the setReleases was called
       expect(mockTerraformModule.setReleases).toHaveBeenCalledOnce();
@@ -495,7 +504,8 @@ describe('releases', () => {
       stubOctokitReturnData('repos.createRelease', mockRelease);
 
       const releasedModules = await createTaggedReleases([mockTerraformModule]);
-      expect(releasedModules).toStrictEqual([mockTerraformModule]);
+      expect(releasedModules).toHaveLength(1);
+      expect(releasedModules[0]).toMatchObject({ module: mockTerraformModule, action: 'created' });
 
       // Verify that the setReleases was called
       expect(mockTerraformModule.setReleases).toHaveBeenCalledOnce();
@@ -541,7 +551,7 @@ describe('releases', () => {
       });
 
       await expect(createTaggedReleases([mockTerraformModule])).rejects.toThrow(
-        'Failed to create tags in repository: string error message',
+        'Failed to create releases/tags in repository: string error message',
       );
       expect(endGroup).toHaveBeenCalled();
     });
@@ -557,7 +567,7 @@ describe('releases', () => {
         await createTaggedReleases([mockTerraformModule]);
       } catch (error) {
         expect(error instanceof Error).toBe(true);
-        expect((error as Error).message).toBe(`Failed to create tags in repository: ${errorMessage}`);
+        expect((error as Error).message).toBe(`Failed to create releases/tags in repository: ${errorMessage}`);
         expect(((error as Error).cause as Error).message).toBe(errorMessage);
       }
       expect(endGroup).toHaveBeenCalled();
@@ -570,6 +580,807 @@ describe('releases', () => {
 
       await expect(createTaggedReleases([mockTerraformModule])).rejects.toThrow(/contents: write/);
       expect(endGroup).toHaveBeenCalled();
+    });
+  });
+
+  describe('createTaggedReleases() - self-healing / idempotency', () => {
+    // The default mock context has prNumber = 1 and prTitle = 'Test Pull Request'. This is the hidden,
+    // schema-versioned marker embedded in every release body AND release commit message we create.
+    const releaseMarker = buildPrMarker(1);
+    const otherPrMarker = buildPrMarker(2);
+    const directory = '/workspace/path/to/test-module';
+
+    /**
+     * Stubs the commit that a module's latest tag points at. This is what the step 2 provenance check
+     * reads to decide whether an existing tag belongs to this pull request.
+     */
+    const stubTagCommitMessage = (message: string) => {
+      stubOctokitReturnData('git.getCommit', { data: { message } });
+    };
+
+    /** A release commit message exactly as createTaggedReleases writes it. */
+    const ourReleaseCommitMessage = (tag: string, marker: string = releaseMarker) =>
+      `${tag}\n\nTest Pull Request\n\nThis is a test pull request body.\n\n${marker}`;
+
+    beforeEach(() => {
+      context.set({ workspaceDir: '/workspace' });
+      execFileSyncMock.mockReset();
+      execFileSyncMock.mockImplementation((_file, args) => {
+        if (Array.isArray(args) && args.includes('rev-parse')) {
+          return Buffer.from('abc123def456');
+        }
+        return Buffer.from('');
+      });
+      context.useMockOctokit();
+    });
+
+    it('step 1: skips a module already released for this pull request (no bump, no tag push)', async () => {
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.1.0', 'path/to/test-module/v1.0.0'],
+        releases: [
+          {
+            id: 2,
+            title: 'path/to/test-module/v1.1.0',
+            tagName: 'path/to/test-module/v1.1.0',
+            body: `## v1.1.0\n\nchangelog\n\n${releaseMarker}`,
+          },
+          {
+            id: 1,
+            title: 'path/to/test-module/v1.0.0',
+            tagName: 'path/to/test-module/v1.0.0',
+            body: 'initial release',
+          },
+        ],
+      });
+      vi.spyOn(module, 'setReleases');
+      vi.spyOn(module, 'setTags');
+
+      expect(module.needsRelease()).toBe(true);
+      const result = await createTaggedReleases([module]);
+
+      // Reported as skipped, carrying the release this pull request actually produced.
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        module,
+        action: 'skipped',
+        releaseTag: 'path/to/test-module/v1.1.0',
+      });
+      expect(result[0].release.body).toContain(releaseMarker);
+      // Nothing was created or pushed, and no provenance lookup was needed.
+      expect(context.octokit.rest.repos.createRelease).not.toHaveBeenCalled();
+      expect(context.octokit.rest.git.getCommit).not.toHaveBeenCalled();
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+      expect(module.setReleases).not.toHaveBeenCalled();
+      expect(module.setTags).not.toHaveBeenCalled();
+      // Commits are cleared so the module no longer needs a release.
+      expect(module.needsRelease()).toBe(false);
+    });
+
+    it('step 1: in a partial retry, skips already-released modules and releases only the missing one', async () => {
+      const releasedModule = createMockTerraformModule({
+        directory: '/workspace/path/to/module-a',
+        commits: [{ sha: 'aaa', message: 'feat: a', files: ['/workspace/path/to/module-a/main.tf'] }],
+        tags: ['path/to/module-a/v1.1.0'],
+        releases: [
+          {
+            id: 10,
+            title: 'path/to/module-a/v1.1.0',
+            tagName: 'path/to/module-a/v1.1.0',
+            body: `## v1.1.0\n\nchangelog\n\n${releaseMarker}`,
+          },
+        ],
+      });
+      const missingModule = createMockTerraformModule({
+        directory: '/workspace/path/to/module-c',
+        commits: [{ sha: 'ccc', message: 'feat: c', files: ['/workspace/path/to/module-c/main.tf'] }],
+        tags: ['path/to/module-c/v1.0.0'],
+        releases: [{ id: 11, title: 'path/to/module-c/v1.0.0', tagName: 'path/to/module-c/v1.0.0', body: 'older' }],
+      });
+      stubOctokitReturnData('repos.createRelease', {
+        data: { id: 999, name: 'path/to/module-c/v1.1.0', tag_name: 'path/to/module-c/v1.1.0', body: 'changelog' },
+      });
+
+      const result = await createTaggedReleases([releasedModule, missingModule]);
+
+      expect(result.map((outcome) => outcome.action)).toStrictEqual(['skipped', 'created']);
+      // Only module-c (step 3) is released — exactly one createRelease targeting its bumped tag.
+      expect(context.octokit.rest.repos.createRelease).toHaveBeenCalledTimes(1);
+      expect(context.octokit.rest.repos.createRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ tag_name: 'path/to/module-c/v1.1.0' }),
+      );
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        expect.anything(),
+        ['push', 'origin', 'path/to/module-c/v1.1.0'],
+        expect.anything(),
+      );
+    });
+
+    it('step 2: recreates the release for an orphan tag proven to belong to this pull request', async () => {
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.1.0', 'path/to/test-module/v1.0.0'],
+        releases: [
+          {
+            id: 1,
+            title: 'path/to/test-module/v1.0.0',
+            tagName: 'path/to/test-module/v1.0.0',
+            body: 'older release from a different pull request',
+          },
+        ],
+      });
+      vi.spyOn(module, 'setReleases');
+      vi.spyOn(module, 'setTags');
+      // The orphan tag's commit carries OUR marker -> it is ours to heal.
+      stubTagCommitMessage(ourReleaseCommitMessage('path/to/test-module/v1.1.0'));
+      stubOctokitReturnData('repos.createRelease', {
+        data: {
+          id: 555,
+          name: 'path/to/test-module/v1.1.0',
+          tag_name: 'path/to/test-module/v1.1.0',
+          body: 'recreated body',
+        },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ action: 'recovered', releaseTag: 'path/to/test-module/v1.1.0' });
+      // Release created for the EXISTING tag (no bump to v1.2.0).
+      expect(context.octokit.rest.repos.createRelease).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tag_name: 'path/to/test-module/v1.1.0',
+          name: 'path/to/test-module/v1.1.0',
+        }),
+      );
+      // No commit/tag/push git operations were performed (release-only recovery).
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+      // The release was added but tags were not modified (the tag already existed).
+      expect(module.setReleases).toHaveBeenCalled();
+      expect(module.setTags).not.toHaveBeenCalled();
+    });
+
+    it('step 2: falls back to the existing tag name and generated changelog when the API returns null name/body', async () => {
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.1.0', 'path/to/test-module/v1.0.0'],
+        releases: [
+          {
+            id: 1,
+            title: 'path/to/test-module/v1.0.0',
+            tagName: 'path/to/test-module/v1.0.0',
+            body: 'older release from a different pull request',
+          },
+        ],
+      });
+      vi.spyOn(module, 'setReleases');
+      stubTagCommitMessage(ourReleaseCommitMessage('path/to/test-module/v1.1.0'));
+      stubOctokitReturnData('repos.createRelease', {
+        data: { id: 556, name: null, tag_name: 'path/to/test-module/v1.1.0', body: null },
+      });
+
+      await createTaggedReleases([module]);
+
+      expect(module.setReleases).toHaveBeenCalledOnce();
+      const newRelease = vi.mocked(module.setReleases).mock.calls[0][0][0];
+      // name was null -> falls back to the existing tag; body was null -> falls back to the generated changelog.
+      expect(newRelease.title).toBe('path/to/test-module/v1.1.0');
+      expect(newRelease.tagName).toBe('path/to/test-module/v1.1.0');
+      expect(newRelease.body).toContain('v1.1.0');
+      expect(newRelease.body).toContain('feat: add feature');
+    });
+
+    it('step 2 provenance: does NOT adopt an orphan tag carrying another pull request’s marker; bumps instead', async () => {
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.1.0', 'path/to/test-module/v1.0.0'],
+        releases: [
+          {
+            id: 1,
+            title: 'path/to/test-module/v1.0.0',
+            tagName: 'path/to/test-module/v1.0.0',
+            body: 'older release',
+          },
+        ],
+      });
+      // The orphan v1.1.0 was pushed by PR #2, whose run died before creating the release.
+      stubTagCommitMessage(ourReleaseCommitMessage('path/to/test-module/v1.1.0', otherPrMarker));
+      stubOctokitReturnData('repos.createRelease', {
+        data: { id: 900, name: 'path/to/test-module/v1.2.0', tag_name: 'path/to/test-module/v1.2.0', body: 'notes' },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result[0]).toMatchObject({ action: 'created', releaseTag: 'path/to/test-module/v1.2.0' });
+      // The foreign orphan tag is left untouched so its owning pull request can still heal it...
+      expect(context.octokit.rest.repos.createRelease).not.toHaveBeenCalledWith(
+        expect.objectContaining({ tag_name: 'path/to/test-module/v1.1.0' }),
+      );
+      // ...and this pull request's own changes are released at the next version.
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        expect.anything(),
+        ['push', 'origin', 'path/to/test-module/v1.2.0'],
+        expect.anything(),
+      );
+      expect(warning).toHaveBeenCalledWith(expect.stringContaining('not produced by this pull request'));
+    });
+
+    it('step 2 provenance: does NOT adopt a pre-existing hand-made tag (adoption case); bumps instead', async () => {
+      // A repo that tagged modules before adopting this action: the tag exists with no release at all.
+      // The old code released onto that tag and never published this pull request's changes.
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.4.0'],
+        releases: [],
+      });
+      stubTagCommitMessage('chore: some unrelated hand-made commit');
+      stubOctokitReturnData('repos.createRelease', {
+        data: { id: 901, name: 'path/to/test-module/v1.5.0', tag_name: 'path/to/test-module/v1.5.0', body: 'notes' },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result[0]).toMatchObject({ action: 'created', releaseTag: 'path/to/test-module/v1.5.0' });
+      expect(context.octokit.rest.repos.createRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ tag_name: 'path/to/test-module/v1.5.0' }),
+      );
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        expect.anything(),
+        ['push', 'origin', 'path/to/test-module/v1.5.0'],
+        expect.anything(),
+      );
+    });
+
+    it('step 2 provenance: adopts a pre-marker tag via the commit-shape fallback', async () => {
+      // Tag created by an older version of the action: no marker, but the release commit still has our
+      // known shape (first line is the tag, body contains the pull request title).
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.1.0', 'path/to/test-module/v1.0.0'],
+        releases: [
+          { id: 1, title: 'path/to/test-module/v1.0.0', tagName: 'path/to/test-module/v1.0.0', body: 'older' },
+        ],
+      });
+      stubTagCommitMessage('path/to/test-module/v1.1.0\n\nTest Pull Request\n\nThis is a test pull request body.');
+      stubOctokitReturnData('repos.createRelease', {
+        data: { id: 902, name: 'path/to/test-module/v1.1.0', tag_name: 'path/to/test-module/v1.1.0', body: 'notes' },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result[0]).toMatchObject({ action: 'recovered', releaseTag: 'path/to/test-module/v1.1.0' });
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('step 2 provenance: treats an unresolvable tag commit as not ours and bumps', async () => {
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.1.0', 'path/to/test-module/v1.0.0'],
+        releases: [
+          { id: 1, title: 'path/to/test-module/v1.0.0', tagName: 'path/to/test-module/v1.0.0', body: 'older' },
+        ],
+      });
+      // An annotated tag object, a deleted commit, or a transient failure.
+      vi.mocked(context.octokit.rest.git.getCommit).mockRejectedValueOnce(
+        new RequestError('Not Found', 404, {
+          request: { method: 'GET', url: '', headers: {} },
+          response: { status: 404, url: '', headers: {}, data: {} },
+        }),
+      );
+      stubOctokitReturnData('repos.createRelease', {
+        data: { id: 903, name: 'path/to/test-module/v1.2.0', tag_name: 'path/to/test-module/v1.2.0', body: 'notes' },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result[0]).toMatchObject({ action: 'created', releaseTag: 'path/to/test-module/v1.2.0' });
+      expect(warning).toHaveBeenCalledWith(expect.stringContaining('to verify ownership'));
+    });
+
+    it('step 2 provenance: treats a non-Error rejection as not ours and bumps', async () => {
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.1.0', 'path/to/test-module/v1.0.0'],
+        releases: [
+          { id: 1, title: 'path/to/test-module/v1.0.0', tagName: 'path/to/test-module/v1.0.0', body: 'older' },
+        ],
+      });
+      vi.mocked(context.octokit.rest.git.getCommit).mockRejectedValueOnce('boom string');
+      stubOctokitReturnData('repos.createRelease', {
+        data: { id: 904, name: 'path/to/test-module/v1.2.0', tag_name: 'path/to/test-module/v1.2.0', body: 'notes' },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result[0]).toMatchObject({ action: 'created' });
+      expect(warning).toHaveBeenCalledWith(expect.stringContaining('boom string'));
+    });
+
+    it('step 1b: skips when the release body was edited but the tag is provably ours', async () => {
+      // A maintainer (or GitHub's "Generate release notes") rewrote the body, stripping the marker.
+      // Without the commit-message corroboration this would bump and publish a duplicate release.
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.1.0', 'path/to/test-module/v1.0.0'],
+        releases: [
+          {
+            id: 2,
+            title: 'path/to/test-module/v1.1.0',
+            tagName: 'path/to/test-module/v1.1.0',
+            body: 'Hand-edited release notes with no marker',
+          },
+          { id: 1, title: 'path/to/test-module/v1.0.0', tagName: 'path/to/test-module/v1.0.0', body: 'older' },
+        ],
+      });
+      stubTagCommitMessage(ourReleaseCommitMessage('path/to/test-module/v1.1.0'));
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result[0]).toMatchObject({ action: 'skipped', releaseTag: 'path/to/test-module/v1.1.0' });
+      expect(context.octokit.rest.repos.createRelease).not.toHaveBeenCalled();
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('step 1b: does not skip when the latest release belongs to another pull request', async () => {
+      // The latest release carries PR #2's marker, so it is unambiguously not ours: no provenance
+      // lookup is needed and we must bump normally.
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.1.0'],
+        releases: [
+          {
+            id: 2,
+            title: 'path/to/test-module/v1.1.0',
+            tagName: 'path/to/test-module/v1.1.0',
+            body: `notes\n\n${otherPrMarker}`,
+          },
+        ],
+      });
+      stubOctokitReturnData('repos.createRelease', {
+        data: { id: 905, name: 'path/to/test-module/v1.2.0', tag_name: 'path/to/test-module/v1.2.0', body: 'notes' },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result[0]).toMatchObject({ action: 'created', releaseTag: 'path/to/test-module/v1.2.0' });
+      expect(context.octokit.rest.git.getCommit).not.toHaveBeenCalled();
+    });
+
+    it('step 3: performs a normal bumped release, stamping the marker into the body AND the commit', async () => {
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.0.0'],
+        releases: [
+          {
+            id: 1,
+            title: 'path/to/test-module/v1.0.0',
+            tagName: 'path/to/test-module/v1.0.0',
+            body: 'older release from a different pull request',
+          },
+        ],
+      });
+      vi.spyOn(module, 'setReleases');
+      vi.spyOn(module, 'setTags');
+      stubOctokitReturnData('repos.createRelease', {
+        data: {
+          id: 777,
+          name: 'path/to/test-module/v1.1.0',
+          tag_name: 'path/to/test-module/v1.1.0',
+          body: 'changelog',
+        },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result[0]).toMatchObject({ action: 'created', releaseTag: 'path/to/test-module/v1.1.0' });
+      // Version bumped to v1.1.0 and a new tag pushed.
+      expect(context.octokit.rest.repos.createRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ tag_name: 'path/to/test-module/v1.1.0' }),
+      );
+      // The created release body carries the hidden marker so future re-runs detect it.
+      expect(context.octokit.rest.repos.createRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ body: expect.stringContaining(releaseMarker) }),
+      );
+      // The release COMMIT also carries the marker, which is what makes the tag provable later.
+      const commitCall = execFileSyncMock.mock.calls.find((call) => Array.isArray(call[1]) && call[1][0] === 'commit');
+      expect(commitCall?.[1]?.[2]).toContain(releaseMarker);
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        expect.anything(),
+        ['push', 'origin', 'path/to/test-module/v1.1.0'],
+        expect.anything(),
+      );
+      expect(module.setTags).toHaveBeenCalled();
+      expect(module.setReleases).toHaveBeenCalled();
+    });
+
+    it('legacy gate: skips (returns []) when a legacy release comment exists and no release carries the marker', async () => {
+      // A pull request completed under the pre-marker scheme: its post-release comment uses the legacy
+      // marker and none of its releases carry our new marker. Preserve the old "don't double-release".
+      stubOctokitReturnData('issues.listComments', {
+        data: [{ id: 1, body: `${LEGACY_PR_RELEASE_COMMENT_MARKER}\nThe following modules have been released:` }],
+      });
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.0.0'],
+        releases: [
+          {
+            id: 1,
+            title: 'path/to/test-module/v1.0.0',
+            tagName: 'path/to/test-module/v1.0.0',
+            body: 'legacy release body with no marker',
+          },
+        ],
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result).toStrictEqual([]);
+      expect(context.octokit.rest.repos.createRelease).not.toHaveBeenCalled();
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('legacy gate: does NOT fire when a release already carries our marker, even alongside a legacy comment', async () => {
+      // Pins the `!anyReleaseHasMarker` conjunct: dropping it would make this pull request skip instead
+      // of self-healing. The legacy comment is present, but a release proves we already ran under the
+      // current scheme, so the gate must not apply.
+      stubOctokitReturnData('issues.listComments', {
+        data: [{ id: 1, body: `${LEGACY_PR_RELEASE_COMMENT_MARKER}\nThe following modules have been released:` }],
+      });
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.1.0'],
+        releases: [
+          {
+            id: 2,
+            title: 'path/to/test-module/v1.1.0',
+            tagName: 'path/to/test-module/v1.1.0',
+            body: `notes\n\n${releaseMarker}`,
+          },
+        ],
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ action: 'skipped', releaseTag: 'path/to/test-module/v1.1.0' });
+    });
+
+    it('legacy gate: still self-heals when the post-release comment uses the current (versioned) marker', async () => {
+      // The post-release comment is from the current scheme (PR_RELEASE_COMMENT_MARKER), so the pull request is
+      // NOT legacy even though no surviving release carries the marker (the release was deleted). The
+      // orphan tag is recovered rather than skipped.
+      stubOctokitReturnData('issues.listComments', {
+        data: [{ id: 1, body: `${PR_RELEASE_COMMENT_MARKER}\nThe following modules have been released:` }],
+      });
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.1.0', 'path/to/test-module/v1.0.0'],
+        releases: [
+          {
+            id: 1,
+            title: 'path/to/test-module/v1.0.0',
+            tagName: 'path/to/test-module/v1.0.0',
+            body: 'older release from a different pull request',
+          },
+        ],
+      });
+      stubTagCommitMessage(ourReleaseCommitMessage('path/to/test-module/v1.1.0'));
+      stubOctokitReturnData('repos.createRelease', {
+        data: {
+          id: 999,
+          name: 'path/to/test-module/v1.1.0',
+          tag_name: 'path/to/test-module/v1.1.0',
+          body: 'recreated body',
+        },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result[0]).toMatchObject({ action: 'recovered', releaseTag: 'path/to/test-module/v1.1.0' });
+      // Orphan tag v1.1.0 recreated (step 2) — not skipped as legacy, and no bump to v1.2.0.
+      expect(context.octokit.rest.repos.createRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ tag_name: 'path/to/test-module/v1.1.0' }),
+      );
+      expect(context.octokit.rest.repos.createRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ body: expect.stringContaining(releaseMarker) }),
+      );
+    });
+
+    it('legacy gate: fails closed when the comment list cannot be read', async () => {
+      // A transient failure must not be silently read as "not legacy" — that would over-bump and
+      // double-release a legacy pull request. Failing is safe: the re-run is idempotent.
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.0.0'],
+        releases: [
+          { id: 1, title: 'path/to/test-module/v1.0.0', tagName: 'path/to/test-module/v1.0.0', body: 'no marker' },
+        ],
+      });
+      vi.mocked(context.octokit.rest.issues.listComments).mockRejectedValueOnce(
+        new RequestError('server blew up', 502, {
+          request: { method: 'GET', url: '', headers: {} },
+          response: { status: 502, url: '', headers: {}, data: {} },
+        }),
+      );
+
+      await expect(createTaggedReleases([module])).rejects.toThrow('Failed to check for a legacy release comment');
+      expect(context.octokit.rest.repos.createRelease).not.toHaveBeenCalled();
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('step 2 provenance: cannot verify a tag with no resolvable commit SHA, so it bumps', async () => {
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        releases: [
+          { id: 1, title: 'path/to/test-module/v1.0.0', tagName: 'path/to/test-module/v1.0.0', body: 'older' },
+        ],
+      });
+      // A tag whose commit SHA is unknown (e.g. an unresolved ref) offers no proof of ownership.
+      module.setTags([{ name: 'path/to/test-module/v1.1.0', commitSHA: '' }]);
+      stubOctokitReturnData('repos.createRelease', {
+        data: { id: 906, name: 'path/to/test-module/v1.2.0', tag_name: 'path/to/test-module/v1.2.0', body: 'notes' },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result[0]).toMatchObject({ action: 'created', releaseTag: 'path/to/test-module/v1.2.0' });
+      expect(context.octokit.rest.git.getCommit).not.toHaveBeenCalled();
+    });
+
+    it('step 2 provenance: treats a commit with a null message as not attributable', async () => {
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.1.0', 'path/to/test-module/v1.0.0'],
+        releases: [
+          { id: 1, title: 'path/to/test-module/v1.0.0', tagName: 'path/to/test-module/v1.0.0', body: 'older' },
+        ],
+      });
+      // The generated Octokit types declare `message` as non-nullable; cast to reproduce a null.
+      stubOctokitReturnData('git.getCommit', { data: { message: null as unknown as string } });
+      stubOctokitReturnData('repos.createRelease', {
+        data: { id: 907, name: 'path/to/test-module/v1.2.0', tag_name: 'path/to/test-module/v1.2.0', body: 'notes' },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result[0]).toMatchObject({ action: 'created', releaseTag: 'path/to/test-module/v1.2.0' });
+    });
+
+    it('initial release: a module with no tags at all skips provenance entirely and creates the first tag', async () => {
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: brand new module', files: [`${directory}/main.tf`] }],
+      });
+      stubOctokitReturnData('repos.createRelease', {
+        data: { id: 908, name: 'path/to/test-module/v1.0.0', tag_name: 'path/to/test-module/v1.0.0', body: 'notes' },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result[0]).toMatchObject({ action: 'created' });
+      expect(context.octokit.rest.git.getCommit).not.toHaveBeenCalled();
+    });
+
+    it('surfaces permissions remediation when the Releases API rejects with a 403', async () => {
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.0.0'],
+        releases: [
+          { id: 1, title: 'path/to/test-module/v1.0.0', tagName: 'path/to/test-module/v1.0.0', body: 'older' },
+        ],
+      });
+      vi.mocked(context.octokit.rest.repos.createRelease).mockRejectedValueOnce(
+        new RequestError('Resource not accessible by integration', 403, {
+          request: { method: 'POST', url: '', headers: {} },
+          response: { status: 403, url: '', headers: {}, data: {} },
+        }),
+      );
+
+      await expect(createTaggedReleases([module])).rejects.toThrow(/contents: write/);
+    });
+
+    it('neutralizes a marker forged in the pull request body before it reaches the release commit', async () => {
+      // The release commit message is the provenance oracle. `git commit -m` uses cleanup=whitespace, so
+      // a marker planted on its own line in a PR description would otherwise survive verbatim into it and
+      // let the forged pull request adopt or skip against this tag.
+      const forged = buildPrMarker(2);
+      context.set({ prBody: `Fixes something.\n\n${forged}` });
+
+      try {
+        const module = createMockTerraformModule({
+          directory,
+          commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+          tags: ['path/to/test-module/v1.0.0'],
+          releases: [
+            { id: 1, title: 'path/to/test-module/v1.0.0', tagName: 'path/to/test-module/v1.0.0', body: 'older' },
+          ],
+        });
+        stubOctokitReturnData('repos.createRelease', {
+          data: { id: 910, name: 'path/to/test-module/v1.1.0', tag_name: 'path/to/test-module/v1.1.0', body: 'notes' },
+        });
+
+        await createTaggedReleases([module]);
+
+        const commitCall = execFileSyncMock.mock.calls.find(
+          (call) => Array.isArray(call[1]) && call[1][0] === 'commit',
+        );
+        const commitMessage = String(commitCall?.[1]?.[2]);
+
+        // The forged marker is escaped and no longer attributable to PR #2...
+        expect(matchesPrMarker(commitMessage, 2)).toBe(false);
+        expect(commitMessage).toContain('&lt;!--');
+        // ...while this pull request's genuine trailing marker still is.
+        expect(matchesPrMarker(commitMessage, 1)).toBe(true);
+      } finally {
+        context.set({ prBody: 'This is a test pull request body.' });
+      }
+    });
+
+    it('pre-marker fallback: rejects a tag whose commit merely CONTAINS this pull request title', async () => {
+      // Bots (Renovate/Dependabot) reuse titles byte-for-byte, so a substring test would make collisions
+      // routine. The fallback requires the exact shape this action writes: line 1 = tag, line 3 = title.
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.1.0', 'path/to/test-module/v1.0.0'],
+        releases: [
+          { id: 1, title: 'path/to/test-module/v1.0.0', tagName: 'path/to/test-module/v1.0.0', body: 'older' },
+        ],
+      });
+      // Another pull request's release commit that merely mentions our title inside its body.
+      stubTagCommitMessage('path/to/test-module/v1.1.0\n\nSome other title\n\nReverts Test Pull Request from before');
+      stubOctokitReturnData('repos.createRelease', {
+        data: { id: 911, name: 'path/to/test-module/v1.2.0', tag_name: 'path/to/test-module/v1.2.0', body: 'notes' },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result[0]).toMatchObject({ action: 'created', releaseTag: 'path/to/test-module/v1.2.0' });
+      expect(warning).toHaveBeenCalledWith(expect.stringContaining('not produced by this pull request'));
+    });
+
+    it('step 1b: the pre-marker heuristic may recover, but must never SKIP a release', async () => {
+      // Skipping is irreversible — it drops a genuine release forever. Recovery leaves a state a re-run
+      // can still correct. So step 1b demands a real marker; the shape heuristic is not enough.
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        tags: ['path/to/test-module/v1.1.0'],
+        releases: [
+          {
+            id: 2,
+            title: 'path/to/test-module/v1.1.0',
+            tagName: 'path/to/test-module/v1.1.0',
+            body: 'A legacy release body with no marker at all',
+          },
+        ],
+      });
+      // Shape matches (heuristic), but there is no marker.
+      stubTagCommitMessage('path/to/test-module/v1.1.0\n\nTest Pull Request\n\nThis is a test pull request body.');
+      stubOctokitReturnData('repos.createRelease', {
+        data: { id: 912, name: 'path/to/test-module/v1.2.0', tag_name: 'path/to/test-module/v1.2.0', body: 'notes' },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result[0]).toMatchObject({ action: 'created', releaseTag: 'path/to/test-module/v1.2.0' });
+      expect(context.octokit.rest.repos.createRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ tag_name: 'path/to/test-module/v1.2.0' }),
+      );
+    });
+
+    it('step 2: heals an orphan tag that is no longer the latest (a later pull request bumped past it)', async () => {
+      // PR #1 pushed v1.1.0 then died before createRelease. PR #2 merged and released v1.2.0. Without
+      // widening the search, #1's re-run would bump to v1.3.0 and publish its older tree as the newest
+      // version, leaving v1.1.0 orphaned forever.
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        releases: [
+          {
+            id: 2,
+            title: 'path/to/test-module/v1.2.0',
+            tagName: 'path/to/test-module/v1.2.0',
+            body: `other PR notes\n\n${otherPrMarker}`,
+          },
+        ],
+      });
+      module.setTags([
+        { name: 'path/to/test-module/v1.2.0', commitSHA: 'sha-v120' },
+        { name: 'path/to/test-module/v1.1.0', commitSHA: 'sha-v110' },
+      ]);
+      stubTagCommitMessage(ourReleaseCommitMessage('path/to/test-module/v1.1.0'));
+      stubOctokitReturnData('repos.createRelease', {
+        data: { id: 920, name: 'path/to/test-module/v1.1.0', tag_name: 'path/to/test-module/v1.1.0', body: 'notes' },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(result[0]).toMatchObject({ action: 'recovered', releaseTag: 'path/to/test-module/v1.1.0' });
+      // Healed at its original version — no bump, no new tag pushed.
+      expect(context.octokit.rest.repos.createRelease).toHaveBeenCalledWith(
+        expect.objectContaining({ tag_name: 'path/to/test-module/v1.1.0' }),
+      );
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+      // v1.2.0 already has a release carrying another PR's marker, so it costs no provenance lookup.
+      expect(context.octokit.rest.git.getCommit).toHaveBeenCalledTimes(1);
+    });
+
+    it('step 2: picks the newest orphan tag that is ours, skipping foreign ones', async () => {
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        releases: [],
+      });
+      module.setTags([
+        { name: 'path/to/test-module/v1.3.0', commitSHA: 'sha-foreign' },
+        { name: 'path/to/test-module/v1.2.0', commitSHA: 'sha-ours' },
+        { name: 'path/to/test-module/v1.1.0', commitSHA: 'sha-older-ours' },
+      ]);
+      stubOctokitImplementation('git.getCommit', ({ commit_sha }) => ({
+        data: {
+          message:
+            commit_sha === 'sha-foreign'
+              ? ourReleaseCommitMessage('path/to/test-module/v1.3.0', otherPrMarker)
+              : ourReleaseCommitMessage(`path/to/test-module/v1.${commit_sha === 'sha-ours' ? 2 : 1}.0`),
+        },
+        status: 200,
+        url: 'https://api.github.com/repos/techpivot/terraform-module-releaser/git/commits',
+        headers: {},
+      }));
+      stubOctokitReturnData('repos.createRelease', {
+        data: { id: 921, name: 'path/to/test-module/v1.2.0', tag_name: 'path/to/test-module/v1.2.0', body: 'notes' },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      // v1.3.0 is foreign; v1.2.0 is the newest one that is ours.
+      expect(result[0]).toMatchObject({ action: 'recovered', releaseTag: 'path/to/test-module/v1.2.0' });
+    });
+
+    it('step 2: caps how many orphan tags are inspected and says so', async () => {
+      const module = createMockTerraformModule({
+        directory,
+        commits: [{ sha: 'abc123', message: 'feat: add feature', files: [`${directory}/main.tf`] }],
+        releases: [],
+      });
+      module.setTags([
+        { name: 'path/to/test-module/v1.5.0', commitSHA: 'sha5' },
+        { name: 'path/to/test-module/v1.4.0', commitSHA: 'sha4' },
+        { name: 'path/to/test-module/v1.3.0', commitSHA: 'sha3' },
+        { name: 'path/to/test-module/v1.2.0', commitSHA: 'sha2' },
+        { name: 'path/to/test-module/v1.1.0', commitSHA: 'sha1' },
+      ]);
+      // None are attributable, so every inspected tag costs a lookup.
+      stubTagCommitMessage('unrelated hand-made commit');
+      stubOctokitReturnData('repos.createRelease', {
+        data: { id: 922, name: 'path/to/test-module/v1.6.0', tag_name: 'path/to/test-module/v1.6.0', body: 'notes' },
+      });
+
+      const result = await createTaggedReleases([module]);
+
+      expect(context.octokit.rest.git.getCommit).toHaveBeenCalledTimes(3);
+      expect(info).toHaveBeenCalledWith(expect.stringContaining('only the newest 3 are checked'));
+      expect(result[0]).toMatchObject({ action: 'created', releaseTag: 'path/to/test-module/v1.6.0' });
+      expect(warning).toHaveBeenCalledWith(expect.stringContaining('not produced by this pull request'));
     });
   });
 

--- a/__tests__/utils/constants.test.ts
+++ b/__tests__/utils/constants.test.ts
@@ -7,7 +7,10 @@ import {
   GITHUB_ACTIONS_BOT_NAME,
   GITHUB_ACTIONS_BOT_USERNAME,
   PROJECT_URL,
-  PR_RELEASE_MARKER,
+  PR_RELEASE_COMMENT_MARKER,
+  LEGACY_PR_RELEASE_COMMENT_MARKER,
+  RELEASE_BODY_PR_MARKER_PREFIX,
+  RELEASE_BODY_PR_MARKER_SCHEMA,
   PR_SUMMARY_MARKER,
   WIKI_TITLE_REPLACEMENTS,
 } from '@/utils/constants';
@@ -38,8 +41,17 @@ describe('utils/constants', () => {
     expect(PR_SUMMARY_MARKER).toBe('<!-- techpivot/terraform-module-releaser — pr-summary-marker -->');
   });
 
-  it('should have the correct PR release marker', () => {
-    expect(PR_RELEASE_MARKER).toBe('<!-- techpivot/terraform-module-releaser — release-marker -->');
+  it('should have the correct (current, versioned) PR release marker', () => {
+    expect(PR_RELEASE_COMMENT_MARKER).toBe('<!-- techpivot/terraform-module-releaser:release:1 -->');
+  });
+
+  it('should preserve the legacy PR release marker content for backward-compatible detection', () => {
+    expect(LEGACY_PR_RELEASE_COMMENT_MARKER).toBe('<!-- techpivot/terraform-module-releaser — release-marker -->');
+  });
+
+  it('should have the correct release-pr marker prefix and schema', () => {
+    expect(RELEASE_BODY_PR_MARKER_PREFIX).toBe('<!-- techpivot/terraform-module-releaser:release-pr:');
+    expect(RELEASE_BODY_PR_MARKER_SCHEMA).toBe(1);
   });
 
   it('should have the correct project URL', () => {

--- a/__tests__/utils/freshness.test.ts
+++ b/__tests__/utils/freshness.test.ts
@@ -1,0 +1,108 @@
+import { context } from '@/mocks/context';
+import { stubOctokitReturnData } from '@/tests/helpers/octokit';
+import { isCheckoutCurrent, pathExistsOnBaseRef } from '@/utils/freshness';
+import { info, warning } from '@actions/core';
+import { RequestError } from '@octokit/request-error';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('utils/freshness', () => {
+  beforeEach(() => {
+    context.useMockOctokit();
+    context.set({ baseRef: 'main', mergeCommitSha: 'merge-commit-sha' });
+  });
+
+  describe('isCheckoutCurrent()', () => {
+    it('returns true when the base branch tip is exactly this pull request’s merge commit', async () => {
+      stubOctokitReturnData('repos.compareCommitsWithBasehead', {
+        data: { status: 'identical', ahead_by: 0, behind_by: 0 },
+      });
+
+      await expect(isCheckoutCurrent()).resolves.toBe(true);
+      expect(context.octokit.rest.repos.compareCommitsWithBasehead).toHaveBeenCalledWith(
+        expect.objectContaining({ basehead: 'merge-commit-sha...main' }),
+      );
+    });
+
+    it('returns false when the base branch has advanced past the merge commit', async () => {
+      stubOctokitReturnData('repos.compareCommitsWithBasehead', {
+        data: { status: 'ahead', ahead_by: 12, behind_by: 0 },
+      });
+
+      await expect(isCheckoutCurrent()).resolves.toBe(false);
+      expect(info).toHaveBeenCalledWith(expect.stringContaining('has advanced 12 commit(s)'));
+    });
+
+    it.each(['behind', 'diverged'] as const)('returns false for a %s comparison', async (status) => {
+      stubOctokitReturnData('repos.compareCommitsWithBasehead', { data: { status, ahead_by: 1, behind_by: 1 } });
+
+      await expect(isCheckoutCurrent()).resolves.toBe(false);
+    });
+
+    it('fails open (true) and warns when the pull request has no merge commit', async () => {
+      context.set({ mergeCommitSha: null });
+
+      await expect(isCheckoutCurrent()).resolves.toBe(true);
+      expect(warning).toHaveBeenCalledWith(expect.stringContaining('Unable to determine'));
+      expect(context.octokit.rest.repos.compareCommitsWithBasehead).not.toHaveBeenCalled();
+    });
+
+    it('fails open (true) and warns when the comparison API errors', async () => {
+      vi.mocked(context.octokit.rest.repos.compareCommitsWithBasehead).mockRejectedValueOnce(
+        new RequestError('boom', 500, {
+          request: { method: 'GET', url: '', headers: {} },
+          response: { status: 500, url: '', headers: {}, data: {} },
+        }),
+      );
+
+      await expect(isCheckoutCurrent()).resolves.toBe(true);
+      expect(warning).toHaveBeenCalledWith(expect.stringContaining('boom'));
+    });
+
+    it('fails open (true) on a non-Error rejection', async () => {
+      vi.mocked(context.octokit.rest.repos.compareCommitsWithBasehead).mockRejectedValueOnce('compare boom');
+
+      await expect(isCheckoutCurrent()).resolves.toBe(true);
+      expect(warning).toHaveBeenCalledWith(expect.stringContaining('compare boom'));
+    });
+  });
+
+  describe('pathExistsOnBaseRef()', () => {
+    it('returns true when the path resolves on the base ref', async () => {
+      await expect(pathExistsOnBaseRef('modules/vpc')).resolves.toBe(true);
+      expect(context.octokit.rest.repos.getContent).toHaveBeenCalledWith(
+        expect.objectContaining({ path: 'modules/vpc', ref: 'main' }),
+      );
+    });
+
+    it('returns false on a definitive 404', async () => {
+      vi.mocked(context.octokit.rest.repos.getContent).mockRejectedValueOnce(
+        new RequestError('Not Found', 404, {
+          request: { method: 'GET', url: '', headers: {} },
+          response: { status: 404, url: '', headers: {}, data: {} },
+        }),
+      );
+
+      await expect(pathExistsOnBaseRef('modules/gone')).resolves.toBe(false);
+      expect(warning).not.toHaveBeenCalled();
+    });
+
+    it('fails open (true) and warns on a non-404 error', async () => {
+      vi.mocked(context.octokit.rest.repos.getContent).mockRejectedValueOnce(
+        new RequestError('rate limited', 403, {
+          request: { method: 'GET', url: '', headers: {} },
+          response: { status: 403, url: '', headers: {}, data: {} },
+        }),
+      );
+
+      await expect(pathExistsOnBaseRef('modules/vpc')).resolves.toBe(true);
+      expect(warning).toHaveBeenCalledWith(expect.stringContaining('rate limited'));
+    });
+
+    it('fails open (true) on a non-Error rejection', async () => {
+      vi.mocked(context.octokit.rest.repos.getContent).mockRejectedValueOnce('content boom');
+
+      await expect(pathExistsOnBaseRef('modules/vpc')).resolves.toBe(true);
+      expect(warning).toHaveBeenCalledWith(expect.stringContaining('content boom'));
+    });
+  });
+});

--- a/__tests__/utils/markers.test.ts
+++ b/__tests__/utils/markers.test.ts
@@ -1,0 +1,176 @@
+import { context } from '@/mocks/context';
+import { RELEASE_BODY_PR_MARKER_PREFIX } from '@/utils/constants';
+import {
+  buildPrMarker,
+  hasAnyPrMarker,
+  hasStandaloneMarkerLine,
+  matchesPrMarker,
+  neutralizePrMarkers,
+} from '@/utils/markers';
+import { describe, expect, it } from 'vitest';
+
+// The mock context repo is techpivot/terraform-module-releaser, so the scoped identity is
+// `techpivot/terraform-module-releaser#<prNumber>`.
+const SLUG = 'techpivot/terraform-module-releaser';
+
+describe('utils/markers', () => {
+  describe('buildPrMarker()', () => {
+    it('builds the schema-versioned, repository-scoped hidden marker for a pull request', () => {
+      expect(buildPrMarker(42)).toBe(`<!-- techpivot/terraform-module-releaser:release-pr:1:${SLUG}#42 -->`);
+    });
+
+    it('scopes the marker to the repository so a fork never adopts an upstream tag', () => {
+      // A fork clones tags but not releases, so every latest tag there is an orphan carrying the
+      // upstream marker — and fork pull request numbering restarts at 1.
+      const upstreamMarker = buildPrMarker(1);
+
+      context.set({ repo: { owner: 'someone', repo: 'my-fork' } });
+      expect(matchesPrMarker(upstreamMarker, 1)).toBe(false);
+      expect(buildPrMarker(1)).toBe('<!-- techpivot/terraform-module-releaser:release-pr:1:someone/my-fork#1 -->');
+
+      context.set({ repo: { owner: 'techpivot', repo: 'terraform-module-releaser' } });
+      expect(matchesPrMarker(upstreamMarker, 1)).toBe(true);
+    });
+  });
+
+  describe('matchesPrMarker()', () => {
+    it('matches a body that carries the current-schema marker for the pull request', () => {
+      const body = `## v1.1.0\n\nchangelog\n\n${buildPrMarker(7)}`;
+      expect(matchesPrMarker(body, 7)).toBe(true);
+    });
+
+    it('matches a future schema version (version-agnostic on the schema digit)', () => {
+      const futureMarker = `<!-- techpivot/terraform-module-releaser:release-pr:2:${SLUG}#7 -->`;
+      expect(matchesPrMarker(`notes\n\n${futureMarker}`, 7)).toBe(true);
+    });
+
+    it('matches the pull request number exactly (the trailing terminator prevents prefix collisions)', () => {
+      const body = buildPrMarker(123);
+      expect(matchesPrMarker(body, 123)).toBe(true);
+      expect(matchesPrMarker(body, 12)).toBe(false);
+      expect(matchesPrMarker(body, 1234)).toBe(false);
+    });
+
+    it('matches a marker on its own line in a CRLF body (the API may return CRLF)', () => {
+      expect(matchesPrMarker(`notes\r\n\r\n${buildPrMarker(7)}\r\n`, 7)).toBe(true);
+    });
+
+    it('tolerates leading and trailing horizontal whitespace around the marker line', () => {
+      expect(matchesPrMarker(`notes\n  \t${buildPrMarker(7)}  \n`, 7)).toBe(true);
+    });
+
+    it('does NOT match a marker embedded mid-line inside prose (anchored to a standalone line)', () => {
+      // This is the forgery vector: attacker-influenced prose that merely contains the marker text.
+      expect(matchesPrMarker(`- fix: something ${buildPrMarker(99)} and more text`, 99)).toBe(false);
+    });
+
+    it('does not match the human-facing [PR #n] changelog link or unrelated content', () => {
+      expect(matchesPrMarker('- [PR #7](https://github.com/o/r/pull/7) - title', 7)).toBe(false);
+      expect(matchesPrMarker('just a changelog with no marker', 7)).toBe(false);
+    });
+
+    it('returns false for an empty, undefined, or null body', () => {
+      expect(matchesPrMarker('', 7)).toBe(false);
+      expect(matchesPrMarker(undefined, 7)).toBe(false);
+      expect(matchesPrMarker(null, 7)).toBe(false);
+    });
+
+    it('matches a commit message whose final line is the marker', () => {
+      // Step 2 provenance relies on this exact shape (see createTaggedReleases).
+      const commitMessage = `modules/vpc/v1.1.0\n\nSome PR title\n\nSome PR body\n\n${buildPrMarker(31)}`;
+      expect(matchesPrMarker(commitMessage, 31)).toBe(true);
+      expect(matchesPrMarker(commitMessage, 32)).toBe(false);
+    });
+
+    it('reports no match when the text carries markers for two different pull requests', () => {
+      // Ambiguity is not ownership. A text naming two producers means something injected a marker;
+      // the safe reading is "not ours", which costs at most a version bump and never a lost release.
+      const ambiguous = `notes\n\n${buildPrMarker(7)}\n\n${buildPrMarker(8)}`;
+
+      expect(matchesPrMarker(ambiguous, 7)).toBe(false);
+      expect(matchesPrMarker(ambiguous, 8)).toBe(false);
+      // ...but it is still recognizably "someone's", so no provenance lookup is wasted on it.
+      expect(hasAnyPrMarker(ambiguous)).toBe(true);
+    });
+
+    it('still matches when the same marker appears more than once', () => {
+      const repeated = `notes\n\n${buildPrMarker(7)}\n\nmore\n\n${buildPrMarker(7)}`;
+      expect(matchesPrMarker(repeated, 7)).toBe(true);
+    });
+  });
+
+  describe('hasStandaloneMarkerLine()', () => {
+    const COMMENT_MARKER = '<!-- techpivot/terraform-module-releaser:release:1 -->';
+
+    it('matches a marker on its own line', () => {
+      expect(hasStandaloneMarkerLine(`${COMMENT_MARKER}\n\n## Releases`, COMMENT_MARKER)).toBe(true);
+      expect(hasStandaloneMarkerLine(`intro\n${COMMENT_MARKER}\ntail`, COMMENT_MARKER)).toBe(true);
+      expect(hasStandaloneMarkerLine(`intro\r\n${COMMENT_MARKER}\r\ntail`, COMMENT_MARKER)).toBe(true);
+    });
+
+    it('does NOT match a quote-replied copy of our comment', () => {
+      // GitHub's "Quote reply" copies raw markdown (hidden HTML comments included) with a `> ` prefix.
+      // Matching it would make a reviewer's comment the newest match, and it would then be overwritten.
+      expect(hasStandaloneMarkerLine(`> ${COMMENT_MARKER}\n>\n> ## Releases`, COMMENT_MARKER)).toBe(false);
+    });
+
+    it('does not match the marker inline within prose', () => {
+      expect(hasStandaloneMarkerLine(`see ${COMMENT_MARKER} here`, COMMENT_MARKER)).toBe(false);
+    });
+
+    it('returns false for empty, undefined, or null bodies', () => {
+      expect(hasStandaloneMarkerLine('', COMMENT_MARKER)).toBe(false);
+      expect(hasStandaloneMarkerLine(undefined, COMMENT_MARKER)).toBe(false);
+      expect(hasStandaloneMarkerLine(null, COMMENT_MARKER)).toBe(false);
+    });
+  });
+
+  describe('hasAnyPrMarker()', () => {
+    it('detects a marker for any pull request', () => {
+      expect(hasAnyPrMarker(`notes\n\n${buildPrMarker(5)}`)).toBe(true);
+      expect(hasAnyPrMarker(`<!-- techpivot/terraform-module-releaser:release-pr:9:${SLUG}#1234 -->`)).toBe(true);
+    });
+
+    it('returns false when no marker is present', () => {
+      expect(hasAnyPrMarker('plain release notes')).toBe(false);
+      expect(hasAnyPrMarker('')).toBe(false);
+      expect(hasAnyPrMarker(undefined)).toBe(false);
+      expect(hasAnyPrMarker(null)).toBe(false);
+    });
+
+    it('does not treat a mid-line marker as present', () => {
+      expect(hasAnyPrMarker(`prose ${buildPrMarker(5)} more prose`)).toBe(false);
+    });
+  });
+
+  describe('neutralizePrMarkers()', () => {
+    it('neutralizes a forged marker so it can no longer be matched', () => {
+      const forged = buildPrMarker(99);
+      const neutralized = neutralizePrMarkers(forged);
+
+      expect(neutralized).not.toBe(forged);
+      expect(matchesPrMarker(`notes\n\n${neutralized}`, 99)).toBe(false);
+      expect(hasAnyPrMarker(`notes\n\n${neutralized}`)).toBe(false);
+    });
+
+    it('escapes only the opening angle bracket, keeping the attempt visible', () => {
+      expect(neutralizePrMarkers(buildPrMarker(99))).toBe(
+        `&lt;!-- techpivot/terraform-module-releaser:release-pr:1:${SLUG}#99 -->`,
+      );
+    });
+
+    it('neutralizes every occurrence', () => {
+      const text = `${buildPrMarker(1)} middle ${buildPrMarker(2)}`;
+      expect(neutralizePrMarkers(text)).not.toContain(RELEASE_BODY_PR_MARKER_PREFIX);
+    });
+
+    it('leaves unrelated HTML comments untouched', () => {
+      const text = '<!-- a normal comment -->\n<!-- another/namespace:thing -->';
+      expect(neutralizePrMarkers(text)).toBe(text);
+    });
+
+    it('returns text without markers unchanged', () => {
+      expect(neutralizePrMarkers('feat: add a feature')).toBe('feat: add a feature');
+    });
+  });
+});

--- a/__tests__/wiki.test.ts
+++ b/__tests__/wiki.test.ts
@@ -11,7 +11,14 @@ import type { ExecSyncError } from '@/types';
 import { WIKI_STATUS } from '@/utils/constants';
 import { removeDirectoryContents } from '@/utils/file';
 
-import { checkoutWiki, commitAndPushWikiChanges, generateWikiFiles, getWikiLink, getWikiStatus } from '@/wiki';
+import {
+  checkoutWiki,
+  commitAndPushWikiChanges,
+  generateWikiFiles,
+  getWikiLink,
+  getWikiStatus,
+  isWikiCheckFailure,
+} from '@/wiki';
 import { endGroup, info, startGroup } from '@actions/core';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -64,6 +71,19 @@ describe('wiki', async () => {
       },
     ],
   );
+
+  describe('isWikiCheckFailure()', () => {
+    it('returns true for every FAILURE_* status', () => {
+      expect(isWikiCheckFailure(WIKI_STATUS.FAILURE_CHECKOUT)).toBe(true);
+      expect(isWikiCheckFailure(WIKI_STATUS.FAILURE_TERRAFORM_DOCS_INSTALL)).toBe(true);
+      expect(isWikiCheckFailure(WIKI_STATUS.FAILURE_TERRAFORM_DOCS_RUN)).toBe(true);
+    });
+
+    it('returns false for non-failure statuses', () => {
+      expect(isWikiCheckFailure(WIKI_STATUS.SUCCESS)).toBe(false);
+      expect(isWikiCheckFailure(WIKI_STATUS.DISABLED)).toBe(false);
+    });
+  });
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'wiki-test-'));

--- a/action.yml
+++ b/action.yml
@@ -226,7 +226,7 @@ outputs:
   changed-module-paths:
     description: JSON array of file system paths to the modules that were changed
   changed-modules-map:
-    description: JSON object mapping module names to their change details including current tag, next tag, and release type
+    description: JSON object mapping module names to their change details including current tag, release tag, release type, and (on merge) the action taken (created, recovered, skipped, or none)
   all-module-names:
     description: JSON array of all module names found in the repository
   all-module-paths:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,30 +58,41 @@ After parsing, the flow branches on event type:
 
 `handlePullRequestMergedEvent()`:
 
-1. **Idempotency check** — `hasReleaseComment()` looks for a hidden HTML comment marker in existing PR comments. If
-   found, exits early (prevents duplicate releases on workflow re-runs)
-2. **Create tagged releases** — For each module needing release:
-   - Copy module files to temp directory (excluding configured patterns)
-   - Copy `.git` directory
-   - Create new commit + tag in temp directory
-   - Push tag to remote
-   - Create GitHub release via API with changelog body
-3. **Post release comment** — Summary of created releases with marker for idempotency
-4. **Delete legacy tags/releases** — Remove orphaned tags from deleted modules (if `delete-legacy-tags` is enabled)
-5. **Generate wiki** — Clone wiki repository, generate/update all module pages, push changes
+1. **Check checkout freshness** — one `repos.compareCommitsWithBasehead` call determines whether the checked-out tree is
+   still the base branch tip. On a re-run of an older merged pull request it is not, and the destructive steps below are
+   skipped. Fails open. See `src/utils/freshness.ts`.
+2. **Create tagged releases** (self-healing & idempotent — see [state-management.md](state-management.md)) — a legacy
+   gate first preserves the old "don't double-release" behavior for pull requests completed under a pre-marker version;
+   then, for each module needing release, the action converges per module rather than blindly creating:
+   - **Already released for this PR?** (release body carries this PR's marker) → skip
+   - **Latest tag is ours and released, but the body was edited?** (release commit carries this PR's marker) → skip
+   - **Orphan latest tag that is provably this PR's?** (tag with no release, release commit carries this PR's marker) →
+     recreate the release for that tag, no bump. A tag that cannot be attributed to this pull request is left alone.
+   - **Otherwise** → copy module files to a temp directory, copy `.git`, commit + tag, push, and create the GitHub
+     release via API with a changelog body plus the hidden PR marker appended
+3. **Post release comment** — idempotent total summary of the releases attributed to _this_ pull request (updated in
+   place on re-runs, never duplicated), carrying the marker
+4. **Delete legacy tags/releases** — Remove orphaned tags from deleted modules (if `delete-legacy-tags` is enabled).
+   _Skipped when the checkout is not current._
+5. **Generate wiki** — Clone wiki repository, generate/update all module pages, push changes. _Skipped when the checkout
+   is not current._
+6. **Re-emit `changed-modules-map`** — with the tag that actually exists plus an `action` field (`created` | `recovered`
+   | `skipped` | `none`).
 
 ### Action Outputs
 
-Six outputs are set via `core.setOutput()` before the merge/release operation:
+Six outputs are set via `core.setOutput()` before the merge/release operation. On a merge run, `changed-modules-map` is
+then **re-emitted** afterwards so `releaseTag` names a tag that really exists (see
+[state-management.md](state-management.md#action-outputs)):
 
-| Output                 | Type        | Description                                                         |
-| ---------------------- | ----------- | ------------------------------------------------------------------- |
-| `changed-module-names` | JSON array  | Module names changed in the PR                                      |
-| `changed-module-paths` | JSON array  | File system paths to changed modules                                |
-| `changed-modules-map`  | JSON object | Module names → change details (current tag, next tag, release type) |
-| `all-module-names`     | JSON array  | All discovered module names                                         |
-| `all-module-paths`     | JSON array  | All discovered module paths                                         |
-| `all-modules-map`      | JSON object | All module names → details (path, latest tag, version)              |
+| Output                 | Type        | Description                                                                      |
+| ---------------------- | ----------- | -------------------------------------------------------------------------------- |
+| `changed-module-names` | JSON array  | Module names changed in the PR                                                   |
+| `changed-module-paths` | JSON array  | File system paths to changed modules                                             |
+| `changed-modules-map`  | JSON object | Module names → change details (current tag, release tag, release type, `action`) |
+| `all-module-names`     | JSON array  | All discovered module names                                                      |
+| `all-module-paths`     | JSON array  | All discovered module paths                                                      |
+| `all-modules-map`      | JSON object | All module names → details (path, latest tag, version)                           |
 
 > **Note**: Outputs are set before `clearCommits()` is called during release, since `needsRelease()` checks commit
 > presence.
@@ -168,10 +179,21 @@ Benefits: Import at module scope without triggering initialization. Test-friendl
 The action filters commits to exclude "phantom" changes — when a file is modified and then reverted within the same PR.
 This prevents unnecessary version bumps from commits that have no net effect on a module.
 
-### Idempotency via PR Comments
+### Idempotency & Self-Healing
 
-A hidden HTML comment (`<!-- techpivot/terraform-module-releaser — release-marker -->`) is embedded in post-release
-comments. On re-runs, `hasReleaseComment()` checks for this marker and exits early if found.
+Releases are idempotent and self-healing per module. Each release we create embeds a hidden, schema-versioned marker
+tying it to the producing pull request — in the release **body** and in the release **commit message**, the latter being
+immutable and therefore the authoritative proof of tag ownership. On a re-run `createTaggedReleases()` skips modules
+already released for the PR, recreates a deleted release for an orphan tag it can prove it created, and otherwise
+live-bumps — so re-runs converge instead of double-releasing. A tag it cannot attribute to this pull request is never
+adopted. A legacy gate keeps the old comment-based protection for pull requests released before this scheme, and fails
+closed if the comment list cannot be read.
+
+The post-release comment is updated in place rather than duplicated, and reports the release attributed to _this_ pull
+request rather than the module's highest release. Because releases are now safe to re-run but stale-tree deletions are
+not, obsolete tag/release cleanup and wiki regeneration are gated on the checkout still being current. Full details
+(markers, provenance, gate, freshness, outputs, backward compatibility) are in
+[state-management.md](state-management.md).
 
 ### Tag Normalization
 

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -1,0 +1,321 @@
+# State Management
+
+This document explains how `terraform-module-releaser` decides what to release on a merge, how it stays **idempotent and
+self-healing** across re-runs, and **why** it stores the small amount of state it needs where it does. It is intended to
+give AI agents and contributors a precise mental model before touching `src/releases.ts`, `src/pull-request.ts`,
+`src/utils/markers.ts`, or `src/utils/freshness.ts`.
+
+## The problem
+
+The merge step (`createTaggedReleases` in `src/releases.ts`) creates a Git tag and a GitHub Release for each changed
+module. Workflows get **re-run** — manually, after a transient failure, or after a user deletes a release. Without care,
+a re-run would:
+
+- **Over-bump** — re-bump from the tag it just created (`v1.1.0` → `v1.2.0`).
+- **Double-release** — create a second release for the same change.
+- **Fail to self-heal** — never restore a release a user deleted by hand.
+
+So the merge step must **converge to the correct state** rather than blindly act. Three invariants:
+
+- **R1 — Idempotency:** re-running a merge never over-bumps and never double-releases.
+- **R2 — Concurrency-correctness:** two pull requests touching the same module both release at sequential versions;
+  neither is silently lost.
+- **R3 — Self-heal:** a deleted release is recreated at the right version; an orphan tag (a tag with no release) **that
+  this pull request produced** gets its release created without bumping.
+
+> R1 and R2 pull in opposite directions. R1 wants a frozen absolute target reconciled by "does it exist?". R2 needs the
+> version computed at merge from the **live** latest tag, because a frozen target collides: if PR #5 froze
+> `module-a → v1.1.0` and PR #6 (also touching `module-a`) merges first and creates `v1.1.0`, then
+> reconcile-by-existence would skip #5 and **silently lose its release**.
+
+## The design
+
+We resolve the R1/R2 tension by **never freezing a version**:
+
+1. **The set of modules to release is recomputed from the pull request's commits at merge** — the same mechanism used on
+   every open-PR run. There is no stored "plan"; the module just does its thing, over and over.
+2. **The version is always live-bumped** from the current latest tag (`TerraformModule.getReleaseTag()` reads `tags[0]`,
+   and tags are fetched fresh each run). Never frozen.
+3. **Idempotency is decided per-module from a durable marker** (below), not from a frozen target and not from a blind
+   early-exit.
+
+### The per-module algorithm (`createTaggedReleases`)
+
+For each module the pull request changed:
+
+1. **Already released for this PR?** A release body carries this PR's marker → **skip** (no bump, no create). Still
+   reported so the post-release comment lists it. _(Normal re-run; partial retry already-done.)_
+1. **Latest tag is ours and already released?** The tag's **release commit** carries this PR's marker but the release
+   body no longer does → **skip**. _(A release body that was hand-edited or replaced by GitHub's "Generate release
+   notes", which strips the marker. Without this the run would bump and publish a duplicate.)_
+1. **Orphan tag that is ours?** Searching this module's tags without releases, newest-first, the first one provably this
+   PR's → **(re)create the release for that existing tag**, at its existing version, no bump and no new tag/commit.
+   _(Crash after tag push; a manually-deleted release whose tag remains; an orphan a later PR has already bumped past.)_
+1. **Otherwise** → bump from the live latest tag, then commit + tag + push + create. _(First release; a tag we cannot
+   attribute to this PR; release+tag both deleted → latest reverts → the bump reproduces the same version; live-bump
+   under concurrency.)_
+
+This needs no stored plan and no new state beyond the marker — everything else is derived from the tags, releases, and
+commits already fetched.
+
+### Provenance: why an orphan tag is not automatically ours
+
+A tag with no release is **not** proof that this pull request created it. It could equally be:
+
+- a tag pushed by hand, or one that predates adoption of this action;
+- a tag left by a **different** pull request whose run died between `git push` and `createRelease`.
+
+Adopting such a tag would attach this pull request's changelog to another commit's tree **and leave this pull request's
+own changes unreleased forever** (step 1 would match on every subsequent re-run). That is a direct R2 violation and, for
+pre-existing tags, a regression against the pre-self-healing behavior.
+
+So every release commit this action creates carries the marker as its final line:
+
+```
+<module>/vX.Y.Z
+
+<pull request title>
+
+<pull request body>
+
+<!-- techpivot/terraform-module-releaser:release-pr:1:<owner>/<repo>#<prNumber> -->
+```
+
+Before adopting a tag, `getTagProvenance` resolves that tag's commit and decides:
+
+1. commit message carries **this** PR's marker → `marker` (**ours**);
+1. commit message carries a marker naming a **different** PR → **definitively not ours**;
+1. **no marker at all** (tag predates the marker scheme) → `heuristic`, and only if the commit matches the
+   release-commit shape **exactly**: line 1 is the tag name and line 3 is this pull request's title.
+
+Anything unresolvable — an annotated tag object, a deleted commit, a transient API error — is treated as **not
+attributable**. Failing to adopt is always recoverable (the owning pull request's re-run heals it); wrongly adopting is
+not.
+
+Two deliberate strictnesses:
+
+- The pre-marker fallback is **shape-exact, not a substring test**. `line 1 === tag` holds for every release commit this
+  action has ever written, so a loose "message contains the title" check would leave the title as the only discriminator
+  — and Renovate and Dependabot reuse titles byte-for-byte across pull requests, which would make a collision routine
+  rather than theoretical.
+- A `heuristic` result may **recover** an orphan tag but may never **skip** a release (step 1b requires a real
+  `marker`). A wrong skip drops a genuine release forever; a wrong recovery leaves a state a re-run can still correct.
+
+The marker is also **repository-scoped** (`<owner>/<repo>#<prNumber>`), because a fork or mirror clone copies tags but
+not releases: every module's latest tag there is an orphan carrying the upstream marker, and fork pull request numbering
+restarts at 1. A bare number would let a fork adopt an upstream tag on a collision.
+
+Finally, a text carrying markers for **two different** pull requests is treated as naming none of them. Ambiguity means
+something injected a marker, and the safe reading costs at most a version bump.
+
+> **Cost.** The provenance lookup only runs when its answer can change the outcome: a tag has no release (step 2), or
+> the latest tag's release carries no marker (step 1b). A release carrying any marker resolves for free. In the steady
+> state — no orphan tags, every release body carrying our marker — it costs **zero** extra API requests. The step 2 scan
+> is capped at `MAX_ORPHAN_TAG_LOOKUPS` (currently 3) per module so a repository full of hand-made tags cannot turn one
+> merge into an unbounded number of lookups; when the cap truncates, the run logs it.
+
+## Where state lives — and why not elsewhere
+
+The only durable state is hidden HTML-comment markers we fully control. We deliberately do **not** introduce external or
+platform state. The options considered and rejected:
+
+| Mechanism                                                 | Verdict                                                                                                                                |
+| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **Release body marker** (chosen tie)                      | Written **atomically with** the release by GitHub; non-expiring; the most crash-robust place to record "this PR released this module." |
+| **Release commit marker** (chosen provenance proof)       | Immutable once pushed — unlike a release body, nobody can edit it — so it is the authoritative proof of tag ownership.                 |
+| **Post-release PR comment marker** (chosen scheme signal) | Easy to read/write; survives; identifies the comment's scheme version.                                                                 |
+| GitHub Actions **artifacts**                              | **Expire** (90-day default, run-scoped), and an action runs inside the consumer's workflow so it would pollute their run storage.      |
+| GitHub Actions **cache**                                  | **Evicted** after 7 days since last access; not durable.                                                                               |
+| Repository **custom properties**                          | Repository-level only — there is **no custom-metadata field on a pull request or issue**.                                              |
+| Pull request **labels**                                   | A flat, length-limited string namespace; cannot hold a structured map.                                                                 |
+| External KV (e.g. Cloudflare)                             | Rejected: this has worked well for 99% of users with no service; building one to cover a sub-1% edge is not worth it.                  |
+
+### Marker (1): the release-body idempotency tie
+
+Each release this action creates embeds a hidden, **schema-versioned** marker tying it to the producing pull request
+(see `src/utils/markers.ts`):
+
+```
+<!-- techpivot/terraform-module-releaser:release-pr:1:<owner>/<repo>#<prNumber> -->
+```
+
+- It is built and matched only through `buildPrMarker` / `matchesPrMarker`, so the writer and the reader can never
+  drift.
+- Detection is **version-agnostic on the schema digit** — a body written by a future `:2:` schema is still recognized by
+  current code, and vice versa. The trailing ` -->` terminator makes the PR-number match exact (`:12` never matches
+  `:123`).
+- Matching is **anchored to a standalone line**. We always write the marker as its own trailing line, so this is exact —
+  and it means a marker sitting mid-sentence inside prose is never honored.
+- The release body is **non-expiring but not immutable**: maintainers, bots, and GitHub's "Generate release notes"
+  button can all rewrite it, which silently removes the marker. That is why the tie is corroborated by the release
+  commit (step 1b above), which cannot be edited.
+- We intentionally do **not** reuse the human-facing `[PR #n]` changelog link as the tie: that text is editable and its
+  format may change. The dedicated marker is purpose-built and under our control.
+- Because the marker lives in the release body, it is also included when release bodies are concatenated into the wiki
+  "full changelog" (`getTerraformModuleFullReleaseChangelog`). This is harmless: it is an HTML comment, so it never
+  renders on the Releases page or in the wiki.
+
+#### Untrusted input is neutralized
+
+Untrusted text reaches **two** places that the idempotency scheme trusts, and both must be neutralized:
+
+1. the **release body**, via `src/changelog.ts` (pull request title and commit messages); and
+2. the **release commit message**, via `createTaggedReleases` (pull request title and body).
+
+The second is the one that matters most, and is easy to miss: it is the text the provenance check reads as proof of
+ownership. `git commit -m` uses `cleanup=whitespace`, so a marker planted on its own line in a pull request description
+survives into the commit verbatim — where the standalone-line anchoring below would _accept_ it. A merged pull request
+whose description contained a marker naming some **other** pull request could therefore make that pull request adopt
+this tag, or skip its own release entirely.
+
+`neutralizePrMarkers` escapes the opening `<` of any marker-shaped sequence at both sites. Unrelated HTML comments a
+user legitimately writes are untouched, and the escaped form renders visibly, so an attempted forgery is obvious rather
+than silent. The standalone-line anchoring and the "two distinct markers means neither" rule are defense in depth behind
+it.
+
+### Marker (2): the post-release comment scheme signal
+
+The post-release comment is identified by `PR_RELEASE_COMMENT_MARKER` (`…:release:1`), distinct from the previous
+`LEGACY_PR_RELEASE_COMMENT_MARKER` (`… — release-marker —`). Their distinctness is the scheme signal.
+
+## Backward / forward compatibility
+
+A re-run does not "freeze" the action version: re-running a workflow replays it with the original commit's workflow
+file, but the action code that executes is whatever the consumer's `uses:` ref resolves to **at re-run time**. A
+SHA/immutable pin runs the original (old) code; a moving tag (`@v2`, `@main`) runs the **current** code against **old
+data**. So the only compatibility burden is a moving-tag consumer re-running a pull request that was released **before**
+they upgraded.
+
+The **legacy gate** at the top of `createTaggedReleases` handles this by reading only our own markers:
+
+```
+legacy = (a post-release comment uses LEGACY_PR_RELEASE_COMMENT_MARKER) AND (no release carries our new marker)
+if (legacy) → skip (preserve the old "don't double-release" behavior)
+else        → run the per-module algorithm, stamping the new marker into every release we create
+```
+
+This is a clean two-way branch, not a chain, and it never parses editable release-note text. It yields a clear contract:
+
+- **New pull requests** are protected by the durable per-release marker — robust even if the user deletes the comment.
+- **Legacy pull requests** retain **exactly their original comment-based protection** — no regression.
+
+> Because the post-release comment is itself versioned, a current-scheme PR whose only release was deleted is **not**
+> mistaken for legacy: its comment carries the new marker, so the gate lets it self-heal.
+
+**The gate fails closed.** If the comment list cannot be read, `hasLegacyPostReleaseComment` throws and the run fails
+rather than assuming "not legacy". A transient 502 or secondary rate limit is indistinguishable from a genuine absence,
+and guessing wrong on a legacy pull request produces an irreversible over-bump plus a duplicate release. Failing is
+cheap precisely because of this refactor: the re-run is idempotent and creates nothing extra. (The comment lookup in
+`addPostReleaseComment` stays best-effort — the worst case there is a duplicate comment.)
+
+### Accepted limitations (rare; documented, not engineered around)
+
+- **Deleted legacy release.** We do not recreate a release deleted from a _legacy_ (pre-marker) pull request — the old
+  code could not either, so this is not a regression. Escape hatch: deleting the legacy post-release comment makes the
+  PR look brand-new, so it will re-release.
+- **Old-action partial failure then upgrade.** If an old version released some modules but crashed before writing its
+  comment, then the action is upgraded and re-run, the already-released modules could re-release — identical to the old
+  version's own behavior.
+- **A foreign orphan tag is never adopted.** The current pull request bumps past it and warns; the tag's owning pull
+  request must be re-run to heal it. This is deliberate — see
+  [Provenance](#provenance-why-an-orphan-tag-is-not-automatically-ours).
+- **Only the newest few orphan tags are healed.** Step 2 inspects at most `MAX_ORPHAN_TAG_LOOKUPS` (currently 3) of a
+  module's tags-without-releases. A pull request whose orphan sits below that many newer orphans bumps instead of
+  healing. The run logs when the cap truncates, so this is never silent. See [Concurrency](#concurrency).
+- **Editing a release body removes the primary tie.** Mitigated by the release-commit corroboration, not eliminated: if
+  both the body is edited _and_ the tag's commit is unresolvable, the module will bump again.
+- **Re-running an old merged pull request does not clean up or regenerate the wiki.** By design — see below.
+- **Action downgrade.** Downgrading the action after releasing under the new scheme is unsupported.
+
+## Re-run side effects and the freshness guard
+
+Removing the old blind early-exit means a merge re-run no longer returns immediately — it performs its normal read work
+and then the per-module self-heal. Releases are safe to re-run. **Deletions computed from a stale tree are not.**
+
+The merge handler mixes two sources of truth: the set of modules comes from the **checked-out tree**
+(`parseTerraformModules` walks `context.workspaceDir`), while tags and releases are fetched **live**. On a re-run of an
+older merged pull request, `actions/checkout` restores that pull request's merge commit, so every module added since is
+absent from the tree. Left unguarded, the cleanup step would classify those modules' tags and releases as orphaned and
+delete them, and wiki regeneration would rewrite the wiki from the stale module list — dropping pages for modules added
+later. The wiki half is not covered by `delete-legacy-tags`, so disabling that input would not protect you.
+
+`isCheckoutCurrent()` (`src/utils/freshness.ts`) resolves this with a single `repos.compareCommitsWithBasehead` call on
+the merge path only. When the base branch has advanced past this pull request's merge commit, the run:
+
+- **still** creates/recovers releases and updates the post-release comment (self-heal is the point of a re-run);
+- **skips** obsolete tag/release cleanup and wiki regeneration, and emits a warning explaining why;
+- **withholds** any module that would be an _initial_ release but no longer exists on the base branch, so a module
+  deleted by a later pull request is not resurrected.
+
+It **fails open**: a null merge commit or an API error assumes the checkout is current, preserving prior behavior rather
+than becoming a new single point of failure.
+
+> **Operator guidance.** To fix a failed wiki generation or to force tag/release cleanup, re-run the workflow of the
+> **most recently merged** pull request. Re-running an older pull request only self-heals that pull request's own
+> releases.
+
+## Action outputs
+
+Because a merge run may skip or recover rather than create, the optimistically computed `releaseTag` is frequently not
+what gets published. `changed-modules-map` is therefore **re-emitted after releases are created** with the tag that
+actually exists, plus an `action` field:
+
+| `action`    | Meaning                                                   | `releaseTag`     |
+| ----------- | --------------------------------------------------------- | ---------------- |
+| `created`   | A new version was bumped, tagged, and released.           | the new tag      |
+| `recovered` | A missing release was created for an existing tag.        | the existing tag |
+| `skipped`   | This pull request had already released the module.        | the existing tag |
+| `none`      | Nothing was released (legacy gate, or withheld as stale). | `null`           |
+
+Consumers should branch on `action` before treating `releaseTag` as a newly published release. The pre-release map is
+still emitted first, so outputs remain populated if the release step throws.
+
+## Concurrency
+
+There is **no concurrency enforcement**, and none is required for correctness — the design self-heals via re-run.
+Releases are created sequentially within a run (see [tagging.md](tagging.md)). For two pull requests racing on the same
+module:
+
+> Both read latest `v1.0.0` and target `v1.1.0`. The first tag push wins; the second push is **rejected** (the ref
+> already exists) → that run errors → its re-run reads the now-live `v1.1.0`, live-bumps to `v1.2.0`, and succeeds. No
+> release is lost and nothing is over-bumped.
+
+A non-racing second PR converges the same way: it finds `v1.1.0` already released by the other PR (its release cites the
+_other_ PR, so step 1 does not match; the tag is not an orphan), so it live-bumps to `v1.2.0`.
+
+The case provenance exists for: PR #5 pushes `v1.1.0` and dies **before** creating the release, then PR #6 merges
+touching the same module. PR #6 sees an orphan tag, proves it belongs to #5, leaves it alone, and releases `v1.2.0` for
+its own changes. **PR #6's changes are not lost, and #5's tag is not hijacked** — which is the property provenance buys.
+
+Re-running #5 then heals `v1.1.0` at its original version, because step 2 searches **every orphan tag newest-first**,
+not just the latest one:
+
+> `v1.2.0` is the latest tag, but it already has a release carrying #6's marker — unambiguously not ours, and resolved
+> without any API call. The next candidate, `v1.1.0`, has no release; its commit carries #5's marker, so it is recovered
+> in place. No bump, no new tag.
+
+Had step 2 only ever considered the latest tag, #5 would instead have bumped to `v1.3.0` and published its older
+workspace tree as the module's newest version — silently reverting #6's changes to that module. Both pull requests end
+up released, at the right versions, in either order.
+
+The scan is bounded (`MAX_ORPHAN_TAG_LOOKUPS`, currently 3) and only considers tags that have **no** release, so a
+healthy repository scans nothing and pays nothing. When the cap truncates, the run logs it rather than silently checking
+fewer.
+
+Optional hardening — a `concurrency:` group, branch-protection "Require branches to be up to date before merging", or
+SHA-pinning the action — is documented as consumer guidance, not a requirement.
+
+## Relevant files
+
+| File                     | Role                                                                                                                              |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `src/releases.ts`        | `createTaggedReleases` — the legacy gate, provenance check, and per-module self-heal algorithm                                    |
+| `src/main.ts`            | merge orchestration, the freshness gate on destructive steps, and outcome-based action outputs                                    |
+| `src/utils/freshness.ts` | `isCheckoutCurrent` / `pathExistsOnBaseRef` — stale-checkout detection                                                            |
+| `src/pull-request.ts`    | `addPostReleaseComment` (idempotent summary), `findReleaseComments`, `hasLegacyPostReleaseComment`                                |
+| `src/utils/markers.ts`   | `buildPrMarker` / `matchesPrMarker` / `hasAnyPrMarker` / `neutralizePrMarkers` — the single source for the tie                    |
+| `src/changelog.ts`       | neutralizes untrusted pull request and commit text before it enters a release body                                                |
+| `src/utils/constants.ts` | `PR_RELEASE_COMMENT_MARKER`, `LEGACY_PR_RELEASE_COMMENT_MARKER`, `RELEASE_BODY_PR_MARKER_PREFIX`, `RELEASE_BODY_PR_MARKER_SCHEMA` |
+
+See also [architecture.md](architecture.md) for the overall execution flow and [tagging.md](tagging.md) for the
+tag/release mechanics.

--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -13,15 +13,16 @@ repo's branching model and mix unrelated module histories together.
 
 ## Key Files
 
-| File                      | Role                                                                   |
-| ------------------------- | ---------------------------------------------------------------------- |
-| `src/releases.ts`         | `createTaggedReleases()` — the main release engine                     |
-| `src/tags.ts`             | `getAllTags()`, `deleteTags()` — read/clean operations                 |
-| `src/terraform-module.ts` | `TerraformModule` domain model, computes next tag/version              |
-| `src/utils/github.ts`     | `configureGitAuthentication()`, `getGitHubActionsBotEmail()`           |
-| `src/utils/constants.ts`  | `GITHUB_ACTIONS_BOT_NAME`, `MODULE_TAG_REGEX`, tag separator constants |
-| `src/utils/file.ts`       | `copyModuleContents()` — excludes patterns before release commit       |
-| `src/changelog.ts`        | `createTerraformModuleChangelog()` — release body generation           |
+| File                      | Role                                                                       |
+| ------------------------- | -------------------------------------------------------------------------- |
+| `src/releases.ts`         | `createTaggedReleases()` — the main release engine                         |
+| `src/tags.ts`             | `getAllTags()`, `deleteTags()` — read/clean operations                     |
+| `src/terraform-module.ts` | `TerraformModule` domain model, computes next tag/version                  |
+| `src/utils/github.ts`     | `configureGitAuthentication()`, `getGitHubActionsBotEmail()`               |
+| `src/utils/constants.ts`  | `GITHUB_ACTIONS_BOT_NAME`, `MODULE_TAG_REGEX`, tag separator constants     |
+| `src/utils/file.ts`       | `copyModuleContents()` — excludes patterns before release commit           |
+| `src/changelog.ts`        | `createTerraformModuleChangelog()` — release body generation               |
+| `src/utils/markers.ts`    | `buildPrMarker()` / `matchesPrMarker()` — release + commit idempotency tie |
 
 ## Tag Naming Convention
 
@@ -57,7 +58,24 @@ The regular expression used is `MODULE_TAG_REGEX`:
 
 ## Release Creation Flow (`createTaggedReleases`)
 
-For each module that `needsRelease()` returns `true`, the action:
+Before the per-module loop, a **legacy gate** runs: if the pull request was completed under a pre-marker version of the
+action (its post-release comment uses `LEGACY_PR_RELEASE_COMMENT_MARKER`) and no release carries the current marker, the
+function returns without releasing, preserving the old "don't double-release" behavior. Otherwise, for each module that
+`needsRelease()` returns `true`, the action converges to the correct state:
+
+- **Step 1 — already released for this PR?** A release body carries this PR's marker → skip (no bump, no create).
+- **Step 1b — latest tag is ours and already released?** The tag's release commit carries this PR's marker but the
+  release body no longer does (edited or regenerated notes) → skip.
+- **Step 2 — orphan tag that is ours?** Searching tags without releases newest-first, the first one provably this PR's →
+  recreate the release for that existing tag, no bump. Bounded by `MAX_ORPHAN_TAG_LOOKUPS`.
+- **Step 3 — otherwise** → live-bump and perform the full release described below.
+
+A tag that cannot be attributed to this pull request — one pushed by hand, predating adoption of this action, or left
+behind by a different pull request that crashed after pushing — is **never** adopted. The run warns, bumps past it, and
+leaves it for its owning pull request's re-run to heal.
+
+The steps below detail **Step 3** (the bump path). See [state-management.md](state-management.md) for the full
+idempotency/self-heal model. For each module released via Step 3, the action:
 
 1. **Creates a temporary directory** (`mkdtempSync`) named after the module.
 2. **Copies module files** into the temp dir using `copyModuleContents()`, respecting `module-asset-exclude-patterns`.
@@ -71,14 +89,15 @@ For each module that `needsRelease()` returns `true`, the action:
    git config --local user.name  "GitHub Actions"
    git config --local user.email "<id>+github-actions[bot]@users.noreply.github.com"
    git add .
-   git commit -m "<releaseTag>\n\n<prTitle>\n\n<prBody>"
+   git commit -m "<releaseTag>\n\n<prTitle>\n\n<prBody>\n\n<hidden PR marker>"
    git tag <releaseTag>
    git push origin <releaseTag>
    ```
 7. **Reads the commit SHA** via `git rev-parse HEAD` immediately after the push (the GitHub API for `createRelease` does
    not return the underlying commit SHA).
 8. **Creates a GitHub Release** via `octokit.rest.repos.createRelease()` using the tag name and a fully rendered
-   changelog body.
+   changelog body **with the hidden PR marker appended** (`buildPrMarker`), so subsequent re-runs detect that this
+   module was already released for this pull request.
 9. **Updates the in-memory `TerraformModule`** with the new release and tag objects, then calls `clearCommits()` to
    prevent re-releasing the same module in the same run.
 
@@ -169,9 +188,19 @@ numeric user ID, making this compatible with any GitHub server.
 - Releases are created **sequentially** (one module at a time) to avoid concurrent `git push` and GitHub API calls
   across modules. Each module gets its own temp dir and `.git` copy, but running releases in parallel would increase the
   risk of API rate limiting and add significant error-handling complexity with no meaningful throughput benefit.
-- **Idempotency on re-runs**: If the workflow re-runs after a partial success, the action checks for a hidden HTML
-  marker in the PR's release comment (`PR_RELEASE_MARKER`) via `hasReleaseComment()`. If the marker exists in any
-  comment, the entire merge handler exits early to avoid duplicate releases.
+- **Idempotency and self-healing on re-runs**: `createTaggedReleases()` is idempotent and self-healing **per module**.
+  Each release we create embeds a hidden, schema-versioned marker tying it to the pull request — in both the release
+  **body** and the release **commit message** (see `src/utils/markers.ts`). On a re-run the function skips modules
+  already released for this PR, recreates a deleted release for an orphan tag **it can prove it created**, and otherwise
+  live-bumps — so re-runs converge instead of over-bumping or double-releasing. There is **no blind early-exit for
+  releases**; a legacy gate preserves the old "don't double-release" behavior for pull requests released by pre-marker
+  versions of the action.
+- **Destructive steps are gated on checkout freshness**: obsolete tag/release cleanup and wiki regeneration derive their
+  "what should exist" set from the checked-out tree while comparing it against live tags, releases, and wiki pages. On a
+  re-run of an older merged pull request that tree is stale, so both steps are skipped (with a warning) when the base
+  branch has advanced past the pull request's merge commit. See `src/utils/freshness.ts`.
+- See [state-management.md](state-management.md) for the full model, the provenance rules, the
+  backward/forward-compatibility contract, and the concurrency analysis.
 
 ## Relationship to `TerraformModule`
 
@@ -186,11 +215,12 @@ immediately, without re-fetching from the API.
 
 ## Relevant Tests
 
-| Test file                            | Coverage focus                                                                          |
-| ------------------------------------ | --------------------------------------------------------------------------------------- |
-| `__tests__/releases.test.ts`         | `createTaggedReleases`, `getAllReleases`, `deleteReleases`, pagination, 403 error paths |
-| `__tests__/tags.test.ts`             | `getAllTags`, `deleteTags`, pagination, 403 error paths                                 |
-| `__tests__/terraform-module.test.ts` | `getReleaseTag`, `getReleaseTagVersion`, `isModuleAssociatedWithTag`, tag normalization |
+| Test file                            | Coverage focus                                                                                   |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| `__tests__/releases.test.ts`         | `createTaggedReleases` (self-healing steps 1–3, legacy gate), `getAllReleases`, `deleteReleases` |
+| `__tests__/tags.test.ts`             | `getAllTags`, `deleteTags`, pagination, 403 error paths                                          |
+| `__tests__/terraform-module.test.ts` | `getReleaseTag`, `getReleaseTagVersion`, `isModuleAssociatedWithTag`, tag normalization          |
+| `__tests__/utils/markers.test.ts`    | `buildPrMarker` / `matchesPrMarker` (version-agnostic marker match)                              |
 
 ## Design Decisions and Trade-offs
 

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -1,16 +1,22 @@
 import { context } from '@/context';
 import type { TerraformModule } from '@/terraform-module';
+import { neutralizePrMarkers } from '@/utils/markers';
 
 /**
  * Creates a changelog entry for a Terraform module.
  *
  * The changelog contains a heading and a list of commits formatted with a timestamp.
  *
+ * Note: the pull request title and commit messages are untrusted input that ends up verbatim in a
+ * release body — which is where the hidden idempotency marker also lives. Both are passed through
+ * {@link neutralizePrMarkers} so a crafted title or commit message can never forge that marker and
+ * suppress another pull request's release. See `src/utils/markers.ts`.
+ *
  * @param {string} heading - The version or tag heading for the changelog entry.
  * @param {readonly string[]} commits - An array of commit messages to include in the changelog.
  * @returns {string} A formatted changelog entry as a string.
  */
-function createTerraformModuleChangelogEntry(heading: string, commits: readonly string[]): string {
+export function createTerraformModuleChangelogEntry(heading: string, commits: readonly string[]): string {
   const { prNumber, prTitle, repoUrl } = context;
   const currentDate = new Date().toISOString().split('T')[0]; // Format: YYYY-MM-DD
   const changelogContent: string[] = [`## \`${heading}\` (${currentDate})\n`];
@@ -19,7 +25,9 @@ function createTerraformModuleChangelogEntry(heading: string, commits: readonly 
   // links the PR in the pull request comments but not automatically in the wiki markdown. In the releases section
   // it will automatically link just the #9 portion but not the PR part. If we link the whole section it
   // ends up being much cleaner.
-  changelogContent.push(`- :twisted_rightwards_arrows:**[PR #${prNumber}](${repoUrl}/pull/${prNumber})** - ${prTitle}`);
+  changelogContent.push(
+    `- :twisted_rightwards_arrows:**[PR #${prNumber}](${repoUrl}/pull/${prNumber})** - ${neutralizePrMarkers(prTitle)}`,
+  );
 
   // Perform some normalization
   const normalizedCommitMessages = commits
@@ -28,7 +36,7 @@ function createTerraformModuleChangelogEntry(heading: string, commits: readonly 
 
     // Trim the commit message and for markdown, newlines that are part of a list format
     // better if they use a <br> tag instead of a newline character.
-    .map((commitMessage) => commitMessage.trim().replace(/\n/g, '<br>'));
+    .map((commitMessage) => neutralizePrMarkers(commitMessage.trim().replace(/\n/g, '<br>')));
 
   for (const normalizedCommit of normalizedCommitMessages) {
     changelogContent.push(`- ${normalizedCommit}`);

--- a/src/context.ts
+++ b/src/context.ts
@@ -46,6 +46,8 @@ function isPullRequestEvent(payload: unknown): payload is PullRequestEvent {
     typeof (payload as PullRequestEvent).pull_request.title === 'string' &&
     ((payload as PullRequestEvent).pull_request.body === null ||
       typeof (payload as PullRequestEvent).pull_request.body === 'string') &&
+    typeof (payload as PullRequestEvent).pull_request.base === 'object' &&
+    typeof (payload as PullRequestEvent).pull_request.base.ref === 'string' &&
     'repository' in payload &&
     typeof (payload as PullRequestEvent).repository === 'object' &&
     typeof (payload as PullRequestEvent).repository.full_name === 'string'
@@ -134,6 +136,8 @@ function initializeContext(): Context {
       prBody: payload.pull_request.body ?? '',
       issueNumber: payload.pull_request.number,
       workspaceDir,
+      baseRef: payload.pull_request.base.ref,
+      mergeCommitSha: payload.pull_request.merge_commit_sha ?? null,
       isPrMergeEvent: payload.action === 'closed' && payload.pull_request.merged === true,
     };
 
@@ -150,6 +154,8 @@ function initializeContext(): Context {
     info(`Pull Request Body: ${truncatedBody}`);
     info(`Issue Number: ${contextInstance.issueNumber}`);
     info(`Workspace Directory: ${contextInstance.workspaceDir}`);
+    info(`Base Ref: ${contextInstance.baseRef}`);
+    info(`Merge Commit SHA: ${contextInstance.mergeCommitSha ?? '(none)'}`);
     info(`Is Pull Request Merge Event: ${contextInstance.isPrMergeEvent}`);
 
     return contextInstance;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,17 @@
+import { relative } from 'node:path';
 import { getConfig } from '@/config';
-import { getContext } from '@/context';
+import { context as actionContext, getContext } from '@/context';
 import { parseTerraformModules } from '@/parser';
-import { addPostReleaseComment, addReleasePlanComment, getPullRequestCommits, hasReleaseComment } from '@/pull-request';
+import { addPostReleaseComment, addReleasePlanComment, getPullRequestCommits } from '@/pull-request';
 import { createTaggedReleases, deleteReleases, getAllReleases } from '@/releases';
 import { deleteTags, getAllTags } from '@/tags';
 import { installTerraformDocs } from '@/terraform-docs';
 import { TerraformModule } from '@/terraform-module';
-import type { Config, Context, GitHubRelease } from '@/types';
+import type { ChangedModuleOutput, Config, Context, GitHubRelease, ReleaseOutcome } from '@/types';
+import { isCheckoutCurrent, pathExistsOnBaseRef } from '@/utils/freshness';
+import { matchesPrMarker } from '@/utils/markers';
 import { checkoutWiki, commitAndPushWikiChanges, generateWikiFiles, getWikiStatus } from '@/wiki';
-import { endGroup, info, setFailed, setOutput, startGroup } from '@actions/core';
+import { endGroup, info, setFailed, setOutput, startGroup, warning } from '@actions/core';
 
 /**
  * Initializes and returns the configuration and context objects.
@@ -48,23 +51,130 @@ async function handlePullRequestEvent(
 }
 
 /**
+ * Withholds modules that would be "resurrected" by a stale checkout.
+ *
+ * Only an *initial* release can resurrect a deleted module: a module that still exists keeps its tags,
+ * whereas one removed by a later pull request had its tags cleaned up and therefore reappears looking
+ * brand new. On a stale checkout we confirm each such module still exists on the base branch before
+ * releasing it.
+ *
+ * @param {TerraformModule[]} terraformModules - All modules detected in the (stale) workspace.
+ * @returns {Promise<TerraformModule[]>} The modules that are safe to release.
+ */
+async function withholdResurrectedModules(terraformModules: TerraformModule[]): Promise<TerraformModule[]> {
+  const { baseRef, workspaceDir } = actionContext;
+  const safeModules: TerraformModule[] = [];
+
+  for (const module of terraformModules) {
+    const isInitialRelease = module.needsRelease() && module.getLatestTag() === null;
+    if (!isInitialRelease || (await pathExistsOnBaseRef(relative(workspaceDir, module.directory)))) {
+      safeModules.push(module);
+      continue;
+    }
+
+    warning(
+      `Module '${module.name}' no longer exists on '${baseRef}' and has no existing tags; it was most likely removed after this pull request merged. Skipping its release to avoid resurrecting a deleted module.`,
+    );
+  }
+
+  return safeModules;
+}
+
+/**
+ * Adds back modules this pull request released on an earlier run but did not process on this one.
+ *
+ * `createTaggedReleases()` only ever sees modules that currently `needsRelease()`. That set shrinks
+ * between runs: a module released solely because it was an *initial* release has a tag afterwards, so
+ * on a re-run it is neither an initial release nor directly changed and drops out entirely. Rendering
+ * the post-release comment from this run's outcomes alone would therefore quietly delete such modules
+ * from the comment, making the pull request's audit trail claim fewer releases than it actually
+ * produced — and it would degrade further on each subsequent re-run.
+ *
+ * The release marker already records the truth durably, so we recover the missing entries from it. The
+ * releases were fetched at the start of the run, so this costs nothing.
+ *
+ * @param {TerraformModule[]} terraformModules - Every module detected in the workspace.
+ * @param {ReleaseOutcome[]} releaseOutcomes - What this run actually created, recovered, or skipped.
+ * @returns {ReleaseOutcome[]} The full set of releases attributable to this pull request.
+ */
+function withPriorReleasesForThisPullRequest(
+  terraformModules: TerraformModule[],
+  releaseOutcomes: ReleaseOutcome[],
+): ReleaseOutcome[] {
+  const { prNumber } = actionContext;
+  const processed = new Set(releaseOutcomes.map((outcome) => outcome.module.name));
+
+  const priorOutcomes: ReleaseOutcome[] = [];
+  for (const module of terraformModules) {
+    if (processed.has(module.name)) {
+      continue;
+    }
+
+    const priorRelease = module.releases.find((release) => matchesPrMarker(release.body, prNumber));
+    if (priorRelease) {
+      priorOutcomes.push({ module, action: 'skipped', releaseTag: priorRelease.tagName, release: priorRelease });
+    }
+  }
+
+  return [...priorOutcomes, ...releaseOutcomes];
+}
+
+/**
  * Handles merge-event-specific operations, including tagging new releases, deleting legacy resources,
  * and optionally generating Terraform Docs-based wiki documentation.
+ *
+ * Release creation always runs: it is idempotent and self-healing, so re-running it converges rather
+ * than duplicating. The **destructive** steps — obsolete tag/release cleanup and wiki regeneration —
+ * are gated on the checked-out tree still being current, because both derive their "what should exist"
+ * set from that tree while comparing it against live tags, releases, and wiki pages. See
+ * {@link isCheckoutCurrent}.
  *
  * @param {Config} config - The configuration object.
  * @param {TerraformModule[]} terraformModules - List of Terraform modules associated with this workspace.
  * @param {GitHubRelease[]} releasesToDelete - List of Terraform releases to delete.
  * @param {string[]} tagsToDelete - List of Terraform tags to delete.
- * @returns {Promise<void>} Resolves when merge-event operations are complete.
+ * @returns {Promise<ReleaseOutcome[]>} What was created, recovered, or skipped for each module.
  */
 async function handlePullRequestMergedEvent(
   config: Config,
   terraformModules: TerraformModule[],
   releasesToDelete: GitHubRelease[],
   tagsToDelete: string[],
-): Promise<void> {
-  const releasedTerraformModules = await createTaggedReleases(terraformModules);
-  await addPostReleaseComment(releasedTerraformModules);
+  changedModulesMap: Record<string, ChangedModuleOutput>,
+): Promise<ReleaseOutcome[]> {
+  const checkoutIsCurrent = await isCheckoutCurrent();
+  const modulesToRelease = checkoutIsCurrent ? terraformModules : await withholdResurrectedModules(terraformModules);
+
+  const releaseOutcomes = await createTaggedReleases(modulesToRelease);
+  const reportedOutcomes = withPriorReleasesForThisPullRequest(terraformModules, releaseOutcomes);
+  await addPostReleaseComment(reportedOutcomes);
+
+  // Re-emit outputs as soon as the release outcomes are known, before the steps that can throw (wiki
+  // generation in particular). Otherwise a wiki failure would leave the optimistic pre-release map —
+  // with a releaseTag that may not exist — as the final value consumers read.
+  setReleaseOutcomeOutputs(changedModulesMap, reportedOutcomes);
+
+  if (!checkoutIsCurrent) {
+    // A bump publishes whatever is in the workspace. On a stale checkout that tree is older than the
+    // module's current state, so the new (highest) version can silently revert changes made after this
+    // pull request merged. Name the affected modules — the run-level warning below does not.
+    for (const { module, releaseTag } of releaseOutcomes.filter((outcome) => outcome.action === 'created')) {
+      warning(
+        `Module '${module.name}' was released as '${releaseTag}' from a checkout that is no longer current, so the published tree may be older than the module's latest state on '${actionContext.baseRef}'.`,
+      );
+    }
+
+    warning(
+      [
+        "The base branch has advanced past this pull request's merge commit, so the checked-out tree is not current.",
+        'Skipping obsolete tag/release cleanup and wiki regeneration to avoid deleting tags, releases, or wiki pages',
+        'belonging to modules added after this pull request merged. Re-run the most recently merged pull request to',
+        'perform cleanup and regenerate the wiki.',
+      ].join(' '),
+    );
+
+    return reportedOutcomes;
+  }
 
   if (!config.deleteLegacyTags) {
     info('Deletion of legacy tags/releases is disabled. Skipping.');
@@ -86,6 +196,8 @@ async function handlePullRequestMergedEvent(
     }
     await commitAndPushWikiChanges();
   }
+
+  return reportedOutcomes;
 }
 
 /**
@@ -112,15 +224,16 @@ async function handlePullRequestMergedEvent(
  * - `releaseType`: The type of release (major, minor, patch) (changed modules only)
  *
  * @param {TerraformModule[]} terraformModules - Array of all Terraform modules detected in the workspace
- * @returns {void} This function has no return value but sets GitHub Action outputs as side effects
+ * @returns {Record<string, ChangedModuleOutput>} The changed-modules map that was emitted, so the merge
+ *  path can re-emit it with the tag that actually ended up being published.
  */
-function setActionOutputs(terraformModules: TerraformModule[]): void {
+function setActionOutputs(terraformModules: TerraformModule[]): Record<string, ChangedModuleOutput> {
   const modulesToRelease = TerraformModule.getModulesNeedingRelease(terraformModules);
 
   // Prepare changed module outputs
   const changedModuleNames = modulesToRelease.map((module) => module.name);
   const changedModulePaths = modulesToRelease.map((module) => module.directory);
-  const changedModulesMap = Object.fromEntries(
+  const changedModulesMap: Record<string, ChangedModuleOutput> = Object.fromEntries(
     modulesToRelease.map((module) => [
       module.name,
       {
@@ -163,18 +276,65 @@ function setActionOutputs(terraformModules: TerraformModule[]): void {
   setOutput('all-module-names', allModuleNames);
   setOutput('all-module-paths', allModulePaths);
   setOutput('all-modules-map', allModulesMap);
+
+  return changedModulesMap;
+}
+
+/**
+ * Re-emits `changed-modules-map` after a merge so it reflects what was actually published.
+ *
+ * The map emitted before releases run carries the optimistically computed next version for every
+ * changed module. That is the right value to expose if the release step then fails — but once releases
+ * are self-healing it is frequently not what gets published: a re-run may skip a module that this pull
+ * request already released, or recover a release onto an existing tag, in both cases leaving
+ * `releaseTag` naming a ref that does not exist. Downstream jobs that check out `releaseTag` would fail.
+ *
+ * Each entry gains an `action` field so consumers can distinguish a fresh release from a skip or a
+ * heal. Modules with no outcome (the legacy gate skipped the pull request, or the module was withheld
+ * on a stale checkout) are reported as `action: 'none'` with a `null` `releaseTag`.
+ *
+ * @param {Record<string, ChangedModuleOutput>} changedModulesMap - The pre-release map.
+ * @param {ReleaseOutcome[]} releaseOutcomes - What actually happened per module.
+ * @returns {void}
+ */
+function setReleaseOutcomeOutputs(
+  changedModulesMap: Record<string, ChangedModuleOutput>,
+  releaseOutcomes: ReleaseOutcome[],
+): void {
+  const outcomesByModuleName = new Map(releaseOutcomes.map((outcome) => [outcome.module.name, outcome]));
+
+  const resolvedModulesMap: Record<string, ChangedModuleOutput> = Object.fromEntries(
+    Object.entries(changedModulesMap).map(([moduleName, entry]) => {
+      const outcome = outcomesByModuleName.get(moduleName);
+
+      return [
+        moduleName,
+        outcome
+          ? { ...entry, releaseTag: outcome.releaseTag, action: outcome.action }
+          : { ...entry, releaseTag: null, action: 'none' as const },
+      ];
+    }),
+  );
+
+  startGroup('GitHub Action Outputs (post-release)');
+  info(`Changed modules map: ${JSON.stringify(resolvedModulesMap, null, 2)}`);
+  endGroup();
+
+  setOutput('changed-modules-map', resolvedModulesMap);
 }
 
 /**
  * Executes the main process of the terraform-module-releaser action.
  *
  * This function handles the Terraform module release workflow by:
- * 1. Checking if a release comment already exists to prevent duplicate releases
- * 2. Collecting pull request commits, tags, and existing releases
- * 3. Identifying Terraform modules and which ones have changed
- * 4. Determining modules that need to be removed
- * 5. Handling either release planning (commenting on PR) or the actual merge event
- * 6. Setting GitHub Action outputs with information about changed and all modules
+ * 1. Collecting pull request commits, tags, and existing releases
+ * 2. Identifying Terraform modules and which ones have changed
+ * 3. Determining modules that need to be removed
+ * 4. Handling either release planning (commenting on PR) or the actual merge event
+ * 5. Setting GitHub Action outputs with information about changed and all modules
+ *
+ * Idempotency is handled per-module during release creation (see createTaggedReleases), so re-runs
+ * converge to the correct state without over-bumping or duplicating releases.
  *
  * The function sets the following outputs:
  * - changed-module-names: Names of modules that changed
@@ -191,23 +351,12 @@ export async function run(): Promise<void> {
   try {
     const { config, context } = initialize();
 
-    if (await hasReleaseComment()) {
-      // Prevent duplicate releases by checking for existing release comments.
-      // This serves as a lightweight state mechanism for the Terraform Release Action.
-      // When a release is completed, a comment is added to the PR. If this comment exists,
-      // it indicates the release has already been processed, preventing:
-      // - Manual workflow re-runs from creating duplicate releases
-      // - Automatic workflow retries from re-releasing the same modules
-      // - Race conditions in concurrent workflow executions
-      //
-      // This approach is preferred over artifact storage as it requires no additional
-      // dependencies, storage permissions, or cleanup - the comment persists with the PR
-      // and provides a clear audit trail of release activity. Another potential solution
-      // might be to add a label to the PR. However, these are easier modified by users
-      // with write permissions while the comment modification would require an admin.
-      info('Release comment found. Exiting.');
-      return;
-    }
+    // Note: We intentionally do NOT short-circuit when a post-release comment already exists. Releases
+    // are made idempotent and self-healing per-module in createTaggedReleases(), which detects what has
+    // already been released for this pull request and only (re)creates what is missing. This is required
+    // so that a re-run can restore a release that was manually deleted (deleting a release does not
+    // remove the post-release comment, so a blind comment-based guard would miss it). The post-release
+    // comment remains as an audit trail; it simply no longer gates control flow.
 
     const commits = await getPullRequestCommits();
     const allTags = await getAllTags();
@@ -219,11 +368,12 @@ export async function run(): Promise<void> {
     // Important: Let's set the action outputs prior to performing the closed/merge request release.
     // This is because the changed modules filters on [module.needsRelease()] which will be false
     // after the release is created. By setting the outputs here, we ensure they accurately reflect
-    // the modules that were changed and needed release at this point in time.
-    setActionOutputs(terraformModules);
+    // the modules that were changed and needed release at this point in time (and that outputs still
+    // exist if the release step throws).
+    const changedModulesMap = setActionOutputs(terraformModules);
 
     if (context.isPrMergeEvent) {
-      await handlePullRequestMergedEvent(config, terraformModules, releasesToDelete, tagsToDelete);
+      await handlePullRequestMergedEvent(config, terraformModules, releasesToDelete, tagsToDelete, changedModulesMap);
     } else {
       await handlePullRequestEvent(terraformModules, releasesToDelete, tagsToDelete);
     }

--- a/src/pull-request.ts
+++ b/src/pull-request.ts
@@ -2,10 +2,18 @@ import { getPullRequestChangelog } from '@/changelog';
 import { config } from '@/config';
 import { context } from '@/context';
 import { TerraformModule } from '@/terraform-module';
-import type { CommitDetails, GitHubRelease, WikiStatusResult } from '@/types';
-import { BRANDING_COMMENT, PROJECT_URL, PR_RELEASE_MARKER, PR_SUMMARY_MARKER, WIKI_STATUS } from '@/utils/constants';
+import type { CommitDetails, GitHubRelease, ReleaseOutcome, WikiStatusResult } from '@/types';
+import {
+  BRANDING_COMMENT,
+  LEGACY_PR_RELEASE_COMMENT_MARKER,
+  PROJECT_URL,
+  PR_RELEASE_COMMENT_MARKER,
+  PR_SUMMARY_MARKER,
+  WIKI_STATUS,
+} from '@/utils/constants';
 
-import { getWikiLink } from '@/wiki';
+import { hasStandaloneMarkerLine } from '@/utils/markers';
+import { getWikiLink, isWikiCheckFailure } from '@/wiki';
 import { debug, endGroup, info, startGroup, warning } from '@actions/core';
 import { RequestError } from '@octokit/request-error';
 
@@ -27,38 +35,95 @@ const MINIMIZE_COMMENT_MUTATION = `
 `;
 
 /**
- * Checks whether the pull request already has a comment containing the release marker.
- *
- * @returns {Promise<boolean>} - Returns true if a comment with the release marker is found, false otherwise.
+ * A pull request comment, reduced to the fields this module needs.
  */
-export async function hasReleaseComment(): Promise<boolean> {
-  try {
-    const {
-      octokit,
-      repo: { owner, repo },
-      issueNumber: issue_number,
-    } = context;
+interface PullRequestComment {
+  id: number;
+  nodeId: string;
+  body: string;
+  createdAt: string;
+}
 
-    // Fetch all comments on the pull request
-    const iterator = octokit.paginate.iterator(octokit.rest.issues.listComments, {
-      owner,
-      repo,
-      issue_number,
-    });
+/**
+ * Lists every comment on the pull request, following pagination to completion.
+ *
+ * Always requests `per_page: 100` (GitHub's default is 30), matching `getAllTags()`/`getAllReleases()`.
+ * On a busy pull request this is the difference between ~16 requests and ~3 — directly relevant to the
+ * rate-limit pressure reported for high-traffic monorepos.
+ *
+ * Note: we deliberately do **not** memoize across calls within a run. The two merge-path readers
+ * (`hasLegacyPostReleaseComment` before releases, `findReleaseComments` after) are cheap at
+ * `per_page: 100`, and a process-lifetime cache would be a silent staleness hazard for future callers.
+ *
+ * @returns {Promise<PullRequestComment[]>} All comments, oldest first (GitHub's listing order).
+ * @throws {Error} If the comments cannot be read. Callers decide whether that is fatal.
+ */
+async function listAllPullRequestComments(): Promise<PullRequestComment[]> {
+  const {
+    octokit,
+    repo: { owner, repo },
+    issueNumber: issue_number,
+  } = context;
 
-    for await (const { data } of iterator) {
-      for (const comment of data) {
-        if (comment.body?.includes(PR_RELEASE_MARKER)) {
-          return true;
-        }
-      }
+  const comments: PullRequestComment[] = [];
+  const iterator = octokit.paginate.iterator(octokit.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number,
+    per_page: 100,
+  });
+  for await (const { data } of iterator) {
+    for (const comment of data) {
+      comments.push({
+        id: comment.id,
+        nodeId: comment.node_id,
+        body: comment.body ?? '',
+        createdAt: comment.created_at,
+      });
     }
+  }
 
-    return false;
+  return comments;
+}
+
+/**
+ * Finds existing post-release comments (current scheme) on the pull request, identified by
+ * {@link PR_RELEASE_COMMENT_MARKER}. Comments are returned in the order GitHub lists them (oldest first), so
+ * callers can take the most recent with `.at(-1)`.
+ *
+ * @returns {Promise<PullRequestComment[]>} The matching post-release comments.
+ */
+async function findReleaseComments(): Promise<PullRequestComment[]> {
+  const comments = await listAllPullRequestComments();
+
+  return comments.filter((comment) => hasStandaloneMarkerLine(comment.body, PR_RELEASE_COMMENT_MARKER));
+}
+
+/**
+ * Returns true if the pull request has a post-release comment written by a PRE-marker-scheme version of
+ * the action (identified by {@link LEGACY_PR_RELEASE_COMMENT_MARKER}).
+ *
+ * Used by the self-heal gate in `createTaggedReleases` to recognize a pull request that completed its
+ * release under an older version of the action — so we preserve the old "don't double-release" behavior
+ * instead of re-releasing. This reads only our own marker, never the editable release-note text.
+ *
+ * **Fails closed.** Any error reading the comment list propagates and fails the run. Returning `false`
+ * on a transient error would be indistinguishable from "not legacy" and would convert a single 502 or
+ * secondary-rate-limit response into an irreversible over-bump plus a duplicate release on a legacy
+ * pull request. Failing is cheap precisely because of this refactor: the re-run is idempotent and
+ * self-healing, so it creates nothing extra.
+ *
+ * @returns {Promise<boolean>} Whether a legacy post-release comment exists.
+ * @throws {Error} If the pull request comments cannot be read.
+ */
+export async function hasLegacyPostReleaseComment(): Promise<boolean> {
+  try {
+    const comments = await listAllPullRequestComments();
+
+    return comments.some((comment) => hasStandaloneMarkerLine(comment.body, LEGACY_PR_RELEASE_COMMENT_MARKER));
   } catch (error) {
     const requestError = error as RequestError;
-    // If we got a 403 because the pull request doesn't have permissions. Let's really help wrap this error
-    // and make it clear to the consumer what actions need to be taken.
+    // Wrap a permissions failure with actionable remediation, matching the other readers in this module.
     if (requestError.status === 403) {
       throw new Error(
         `Unable to read and write pull requests due to insufficient permissions. Ensure the workflow permissions.pull-requests is set to "write".\n${requestError.message}`,
@@ -66,9 +131,10 @@ export async function hasReleaseComment(): Promise<boolean> {
       );
     }
 
-    throw new Error(`Error checking PR comments: ${error instanceof Error ? error.message : String(error)}`, {
-      cause: error,
-    });
+    throw new Error(
+      `Failed to check for a legacy release comment: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
   }
 }
 
@@ -234,11 +300,7 @@ export async function addReleasePlanComment(
     // Initialize the comment body as an array of strings with appropriate header based on wiki status
     const commentBody: string[] = [PR_SUMMARY_MARKER];
 
-    if (
-      wikiStatus.status === WIKI_STATUS.FAILURE_CHECKOUT ||
-      wikiStatus.status === WIKI_STATUS.FAILURE_TERRAFORM_DOCS_RUN ||
-      wikiStatus.status === WIKI_STATUS.FAILURE_TERRAFORM_DOCS_INSTALL
-    ) {
+    if (isWikiCheckFailure(wikiStatus.status)) {
       commentBody.push('\n# ⚠️ Release Plan\n', '> ⚠️ **IMPORTANT**: _See Wiki Status error below._\n');
     } else {
       commentBody.push('\n# 📋 Release Plan\n');
@@ -399,16 +461,15 @@ export async function addReleasePlanComment(
     // When `hide-no-changes-pr-comment` is enabled and this pull request has nothing to report,
     // avoid spamming reviewers with a "Release Plan" comment. A pull request has "nothing to report"
     // when no modules need a release, no tag/release cleanup is pending, and the wiki check did not fail.
-    const wikiCheckFailed =
-      wikiStatus.status === WIKI_STATUS.FAILURE_CHECKOUT ||
-      wikiStatus.status === WIKI_STATUS.FAILURE_TERRAFORM_DOCS_RUN ||
-      wikiStatus.status === WIKI_STATUS.FAILURE_TERRAFORM_DOCS_INSTALL;
+    const wikiCheckFailed = isWikiCheckFailure(wikiStatus.status);
     const hasPendingCleanup = config.deleteLegacyTags && (releasesToDelete.length > 0 || tagsToDelete.length > 0);
     const nothingToReport = terraformModulesToRelese.length === 0 && !hasPendingCleanup && !wikiCheckFailed;
 
     if (config.hideNoChangesPrComment && nothingToReport) {
-      const { data: allComments } = await octokit.rest.issues.listComments({ issue_number, owner, repo });
-      const existingSummaryComments = allComments.filter((comment) => comment.body?.includes(PR_SUMMARY_MARKER));
+      const allComments = await listAllPullRequestComments();
+      const existingSummaryComments = allComments.filter((comment) =>
+        hasStandaloneMarkerLine(comment.body, PR_SUMMARY_MARKER),
+      );
 
       // Keep the most recent existing Release Plan comment, if any. `.at(-1)` returns undefined when
       // none exist, in which case we post nothing (no comment, no email notification).
@@ -436,7 +497,7 @@ export async function addReleasePlanComment(
         );
       }
       try {
-        await octokit.graphql(MINIMIZE_COMMENT_MUTATION, { id: commentToKeep.node_id });
+        await octokit.graphql(MINIMIZE_COMMENT_MUTATION, { id: commentToKeep.nodeId });
       } catch (error) {
         warning(
           `Failed to minimize release plan comment ${commentToKeep.id}: ${error instanceof Error ? error.message : String(error)}`,
@@ -445,7 +506,7 @@ export async function addReleasePlanComment(
 
       // Remove any older summary comments so only the single minimized comment remains.
       for (const comment of existingSummaryComments.slice(0, -1)) {
-        info(`Deleting previous PR comment from ${comment.created_at}`);
+        info(`Deleting previous PR comment from ${comment.createdAt}`);
         await octokit.rest.issues.deleteComment({ comment_id: comment.id, owner, repo });
       }
 
@@ -462,14 +523,14 @@ export async function addReleasePlanComment(
     info(`Posted comment ${newComment.id} @ ${newComment.html_url}`);
 
     // Filter out the comments that contain the PR summary marker and are not the current comment
-    const { data: allComments } = await octokit.rest.issues.listComments({ issue_number, owner, repo });
+    const allComments = await listAllPullRequestComments();
     const commentsToDelete = allComments.filter(
-      (comment) => comment.body?.includes(PR_SUMMARY_MARKER) && comment.id !== newComment.id,
+      (comment) => hasStandaloneMarkerLine(comment.body, PR_SUMMARY_MARKER) && comment.id !== newComment.id,
     );
 
     // Delete all our previous comments
     for (const comment of commentsToDelete) {
-      info(`Deleting previous PR comment from ${comment.created_at}`);
+      info(`Deleting previous PR comment from ${comment.createdAt}`);
       await octokit.rest.issues.deleteComment({ comment_id: comment.id, owner, repo });
     }
   } catch (error) {
@@ -494,14 +555,19 @@ export async function addReleasePlanComment(
 }
 
 /**
- * Adds a comment to the pull request with details about the releases created as specified via the
- * releasedTerraformModules.
+ * Adds a comment to the pull request with details about the releases attributed to this pull request.
  *
- * @param {TerraformModule[]} releasedTerraformModules - Array of released/updated Terraform modules.
+ * Takes {@link ReleaseOutcome}s rather than modules because a module's highest release is not
+ * necessarily *this* pull request's release: once releases are self-healing, a re-run may skip a module
+ * that a later pull request has since bumped past. Reporting `module.releases[0]` in that situation
+ * would rewrite this pull request's own comment to cite another pull request's version, tag link and
+ * release notes — and would do so again on every subsequent re-run, since the body never converges.
+ *
+ * @param {ReleaseOutcome[]} releaseOutcomes - What was created, recovered, or skipped for each module.
  * @returns {Promise<void>}
  */
-export async function addPostReleaseComment(releasedTerraformModules: TerraformModule[]): Promise<void> {
-  if (releasedTerraformModules.length === 0) {
+export async function addPostReleaseComment(releaseOutcomes: ReleaseOutcome[]): Promise<void> {
+  if (releaseOutcomes.length === 0) {
     info('No released modules. Skipping post release PR comment.');
     return;
   }
@@ -519,19 +585,18 @@ export async function addPostReleaseComment(releasedTerraformModules: TerraformM
 
     // Construct the comment body as an array of strings
     const commentBody: string[] = [
-      PR_RELEASE_MARKER,
+      PR_RELEASE_COMMENT_MARKER,
       '\n## :rocket: Terraform Module Releases\n',
       'The following Terraform modules have been released:\n',
     ];
 
-    for (const terraformModule of releasedTerraformModules) {
-      const latestRelease: GitHubRelease = terraformModule.releases[0];
-      const extra = [`[Release Notes](${repoUrl}/releases/tag/${latestRelease.tagName})`];
+    for (const { module, release } of releaseOutcomes) {
+      const extra = [`[Release Notes](${repoUrl}/releases/tag/${release.tagName})`];
       if (config.disableWiki === false) {
-        extra.push(`[Wiki/Usage](${getWikiLink(terraformModule.name, false)})`);
+        extra.push(`[Wiki/Usage](${getWikiLink(module.name, false)})`);
       }
 
-      commentBody.push(`- **\`${latestRelease.title}\`** • ${extra.join(' • ')}`);
+      commentBody.push(`- **\`${release.title}\`** • ${extra.join(' • ')}`);
     }
 
     // Branding
@@ -539,14 +604,47 @@ export async function addPostReleaseComment(releasedTerraformModules: TerraformM
       commentBody.push(`\n${BRANDING_COMMENT}`);
     }
 
-    // Post the comment on the pull request
-    const { data: newComment } = await octokit.rest.issues.createComment({
-      owner,
-      repo,
-      issue_number,
-      body: commentBody.join('\n').trim(),
-    });
-    info(`Posted comment ${newComment.id} @ ${newComment.html_url}`);
+    const body = commentBody.join('\n').trim();
+
+    // Idempotent: update the existing post-release comment in place rather than posting a duplicate on a
+    // re-run. Editing keeps the comment's timeline position and sends no new email notification. The body
+    // must reflect the full set of this pull request's released modules — note that the caller is
+    // responsible for that completeness, since a re-run only processes modules that still need a
+    // release (see `withPriorReleasesForThisPullRequest` in src/main.ts). Best-effort lookup: if listing comments fails, fall back to
+    // creating a new comment instead of failing the merge.
+    let existingComments: { id: number; body: string }[] = [];
+    try {
+      existingComments = await findReleaseComments();
+    } catch (error) {
+      warning(
+        `Failed to list existing post-release comments; will create a new one: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    const commentToKeep = existingComments.at(-1);
+    if (commentToKeep) {
+      if (commentToKeep.body.trim() === body) {
+        info(`Post-release comment ${commentToKeep.id} is already up to date. Nothing to do.`);
+      } else {
+        await octokit.rest.issues.updateComment({ owner, repo, comment_id: commentToKeep.id, body });
+        info(`Updated post-release comment ${commentToKeep.id} in place.`);
+      }
+
+      // Consolidate: remove any older duplicate post-release comments so only the most recent remains.
+      for (const comment of existingComments.slice(0, -1)) {
+        info(`Deleting duplicate post-release comment ${comment.id}`);
+        try {
+          await octokit.rest.issues.deleteComment({ owner, repo, comment_id: comment.id });
+        } catch (error) {
+          warning(
+            `Failed to delete duplicate post-release comment ${comment.id}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+    } else {
+      const { data: newComment } = await octokit.rest.issues.createComment({ owner, repo, issue_number, body });
+      info(`Posted comment ${newComment.id} @ ${newComment.html_url}`);
+    }
   } catch (error) {
     if (error instanceof RequestError) {
       throw new Error(

--- a/src/releases.ts
+++ b/src/releases.ts
@@ -2,20 +2,32 @@ import { type ExecSyncOptions, execFileSync } from 'node:child_process';
 import { cpSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createTerraformModuleChangelog } from '@/changelog';
+import { createTerraformModuleChangelog, createTerraformModuleChangelogEntry } from '@/changelog';
 import { config } from '@/config';
 import { context } from '@/context';
+import { hasLegacyPostReleaseComment } from '@/pull-request';
 import { TerraformModule } from '@/terraform-module';
-import type { GitHubRelease } from '@/types';
+import type { GitHubRelease, ReleaseOutcome } from '@/types';
 import { GITHUB_ACTIONS_BOT_NAME } from '@/utils/constants';
 import { copyModuleContents } from '@/utils/file';
 import { configureGitAuthentication, getGitHubActionsBotEmail } from '@/utils/github';
-import { debug, endGroup, info, startGroup } from '@actions/core';
+import { buildPrMarker, hasAnyPrMarker, matchesPrMarker, neutralizePrMarkers } from '@/utils/markers';
+import { debug, endGroup, info, startGroup, warning } from '@actions/core';
 import type { RestEndpointMethodTypes } from '@octokit/plugin-rest-endpoint-methods';
 import { RequestError } from '@octokit/request-error';
 import which from 'which';
 
 type ListReleasesParams = Omit<RestEndpointMethodTypes['repos']['listReleases']['parameters'], 'owner' | 'repo'>;
+
+/**
+ * How many of a module's orphan tags (tags with no release) are checked for recoverability on a merge.
+ *
+ * Each check costs one Git Data API request, and only tags without a release are candidates — so in a
+ * healthy repository this is zero. The cap bounds the worst case (a repository full of hand-made tags)
+ * so one merge cannot fan out into an unbounded number of lookups. When it truncates, the run says so
+ * rather than silently checking fewer.
+ */
+const MAX_ORPHAN_TAG_LOOKUPS = 3;
 
 /**
  * Retrieves all releases from the specified GitHub repository.
@@ -84,15 +96,118 @@ export async function getAllReleases(
 }
 
 /**
- * Creates a GitHub release and corresponding git tag for each Terraform modules that needs a release.
+ * How strongly an existing tag can be tied to the current pull request.
+ *
+ * - `marker` — the tag's release commit carries this pull request's marker. Cryptographically boring
+ *   but authoritative: the commit message is immutable once pushed, and untrusted text is neutralized
+ *   before it is written.
+ * - `heuristic` — the commit carries no marker at all (it predates the marker scheme) but matches the
+ *   exact shape this action writes. Good enough to *recover* an orphan tag, never good enough to
+ *   *skip* a release.
+ * - `unknown` — not ours, or not provable.
+ */
+type TagProvenance = 'marker' | 'heuristic' | 'unknown';
+
+/**
+ * Determines how confidently an existing git tag can be attributed to the **current** pull request.
+ *
+ * This is the provenance check that makes self-healing safe. A tag with no release is not
+ * automatically ours: it may be a tag pushed by hand, a tag that predates adoption of this action, or
+ * a tag left behind by a *different* pull request whose run died between `git push` and
+ * `createRelease`. Adopting such a tag would attach this pull request's changelog to another commit's
+ * tree and, worse, leave this pull request's own changes unreleased forever.
+ *
+ * Resolution order, most certain first:
+ * 1. The tag's commit message carries **this** pull request's marker → `marker`.
+ * 2. The tag's commit message carries a marker naming a **different** pull request → `unknown`.
+ * 3. No marker at all (the tag predates the marker scheme) → require the exact shape this action
+ *    writes: line 1 is the tag name and line 3 is this pull request's title → `heuristic`.
+ *
+ * The pre-marker case is deliberately shape-exact rather than a substring test. `line 1 === tagName`
+ * holds for *every* release commit this action has ever written, so a loose `includes(prTitle)` would
+ * leave the pull request title as the only discriminator — and bots such as Renovate and Dependabot
+ * reuse titles byte-for-byte across pull requests, which would make a collision routine rather than
+ * theoretical.
+ *
+ * Any failure to resolve the commit (a tag pointing at an annotated tag object, a deleted commit, a
+ * transient API error) is treated as **not attributable**. Failing to adopt is always recoverable —
+ * the owning pull request's own re-run will heal it — whereas wrongly adopting is not.
+ *
+ * @param {string} tagName - The tag being considered for adoption.
+ * @param {string | null} commitSHA - The commit the tag points at.
+ * @returns {Promise<TagProvenance>} How strongly the tag ties to the current pull request.
+ */
+async function getTagProvenance(tagName: string, commitSHA: string | null): Promise<TagProvenance> {
+  // No resolvable commit means no proof of ownership. Treat an empty SHA the same as a missing one.
+  if (!commitSHA) {
+    return 'unknown';
+  }
+
+  const {
+    octokit,
+    repo: { owner, repo },
+    prNumber,
+    prTitle,
+  } = context;
+
+  let commitMessage: string;
+  try {
+    // Use the Git Data API rather than repos.getCommit: we only need the message, and a release commit
+    // is built in a temp directory with `git add .`, so its diff nominally deletes every other file in
+    // the repository. repos.getCommit would return that entire `files[]` array (with patches) to read
+    // one string.
+    const { data } = await octokit.rest.git.getCommit({ owner, repo, commit_sha: commitSHA });
+    commitMessage = data.message ?? '';
+  } catch (error) {
+    warning(
+      `Could not resolve commit ${commitSHA} for tag '${tagName}' to verify ownership; treating it as not belonging to this pull request: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return 'unknown';
+  }
+
+  if (matchesPrMarker(commitMessage, prNumber)) {
+    return 'marker';
+  }
+
+  if (hasAnyPrMarker(commitMessage)) {
+    return 'unknown';
+  }
+
+  // Pre-marker fallback: the release commit shape this action has always written, matched exactly.
+  const lines = commitMessage.split('\n');
+  const shapeMatches = lines[0]?.trim() === tagName && prTitle.length > 0 && lines[2]?.trim() === prTitle;
+
+  return shapeMatches ? 'heuristic' : 'unknown';
+}
+
+/**
+ * Creates a GitHub release and corresponding git tag for each Terraform module that needs a release.
+ *
+ * This operation is self-healing and idempotent. For each module that needs a release, it converges to
+ * the correct state rather than blindly creating a release (which would over-bump versions on a re-run):
+ *
+ * 1. If the module already has a release for the current pull request (its body carries our marker),
+ *    it is skipped — no bump, no create — but still reported so the post-release comment lists it.
+ * 1b. If the latest tag is provably this pull request's and already has a release, the module is also
+ *    skipped. This covers a release whose body was edited or regenerated, which strips the marker and
+ *    would otherwise re-arm a bump and a duplicate release.
+ * 2. Otherwise, if the latest tag is provably this pull request's and has **no** release (an orphan
+ *    tag from a partial failure, or a manually-deleted release), the missing release is created for
+ *    that existing tag without bumping the version or pushing a new commit/tag.
+ * 3. Otherwise, a normal release is performed: the version is bumped and a commit, tag, and release
+ *    are created.
+ *
+ * A tag that cannot be attributed to this pull request is never adopted; the run bumps past it and
+ * leaves it for its owning pull request's re-run to heal. See `docs/state-management.md`.
  *
  * Note: Requires GitHub action permissions > contents: write
  *
  * @param {TerraformModule[]} terraformModules - An array of Terraform module objects containing
  *  module metadata, version information, and release status.
- * @returns {Promise<TerraformModule[]>} Updated TerraformModule instances with new releases and tags
+ * @returns {Promise<ReleaseOutcome[]>} What was actually done for each module, including the tag that
+ *  really exists and the release attributed to this pull request.
  */
-export async function createTaggedReleases(terraformModules: TerraformModule[]): Promise<TerraformModule[]> {
+export async function createTaggedReleases(terraformModules: TerraformModule[]): Promise<ReleaseOutcome[]> {
   const terraformModulesToRelease = TerraformModule.getModulesNeedingRelease(terraformModules);
 
   // Check if there are any modules to process
@@ -108,19 +223,161 @@ export async function createTaggedReleases(terraformModules: TerraformModule[]):
     octokit,
     repo: { owner, repo },
     prBody,
+    prNumber,
     prTitle,
     workspaceDir,
   } = context;
 
+  // Each release we create embeds a hidden, schema-versioned marker tying it to this pull request (see
+  // src/utils/markers.ts). The same marker is written into the release commit message, which is what
+  // later lets us prove that an existing tag was produced by this pull request. We scan for it so that
+  // re-runs converge to the correct state instead of over-bumping or duplicating releases.
+  const releaseMarker = buildPrMarker(prNumber);
+
+  // Legacy gate: if this pull request was already completed under the pre-marker scheme (its post-release
+  // comment uses LEGACY_PR_RELEASE_COMMENT_MARKER) and none of its releases carry our marker, preserve the old
+  // "don't double-release" behavior by skipping. This reads only our own markers — never the editable
+  // release-note text — so it is robust and unambiguous. A pull request released under the current scheme
+  // carries the new comment marker, so it is not treated as legacy and continues to self-heal.
+  const anyReleaseHasMarker = terraformModulesToRelease.some((module) =>
+    module.releases.some((release) => matchesPrMarker(release.body, prNumber)),
+  );
+  if (!anyReleaseHasMarker && (await hasLegacyPostReleaseComment())) {
+    info(
+      'Legacy release marker found; this pull request completed under the pre-marker scheme. Skipping release creation to avoid double-releasing.',
+    );
+    return [];
+  }
+
   console.time('Elapsed time pushing new tags & release');
   startGroup('Creating releases & tags for modules');
+
+  const outcomes: ReleaseOutcome[] = [];
 
   try {
     for (const module of terraformModulesToRelease) {
       const moduleName = module.name;
+      info(`Processing module: ${moduleName}`);
+
+      // Step 1: Has this module already been released for this pull request? This makes re-runs
+      // idempotent — a retried or re-run merge will not bump or re-create a release for a module that
+      // was already released by this pull request (which would otherwise over-bump the version). It is
+      // still reported (returned below) so the post-release comment lists it.
+      const existingPrRelease = module.releases.find((release) => matchesPrMarker(release.body, prNumber));
+      if (existingPrRelease) {
+        info(`Module '${moduleName}' already released for this pull request (${existingPrRelease.title}). Skipping.`);
+        module.clearCommits();
+        outcomes.push({
+          module,
+          action: 'skipped',
+          releaseTag: existingPrRelease.tagName,
+          release: existingPrRelease,
+        });
+        continue;
+      }
+
+      const latestTag = module.getLatestTag();
+      const releaseForLatestTag =
+        latestTag === null ? undefined : module.releases.find((release) => release.tagName === latestTag);
+
+      // Step 1b: the latest tag is ours and already has a release, but that release's body no longer
+      // carries our marker (edited by hand, or replaced by GitHub's "Generate release notes"). Without
+      // this, step 1 would miss and step 3 would bump and publish a duplicate release.
+      //
+      // A release carrying another pull request's marker is unambiguously not ours, so no lookup is
+      // needed — which means the steady state (every release body carrying a marker) costs nothing.
+      //
+      // This requires a real `marker`, never the pre-marker heuristic. Skipping is irreversible: a
+      // wrong answer here silently drops a genuine release forever, whereas a wrong answer in step 2
+      // leaves a state a re-run can still correct.
+      if (latestTag !== null && releaseForLatestTag !== undefined && !hasAnyPrMarker(releaseForLatestTag.body)) {
+        const latestProvenance = await getTagProvenance(latestTag, module.getLatestTagCommitSHA());
+        if (latestProvenance === 'marker') {
+          info(
+            `Module '${moduleName}' was already released by this pull request as '${releaseForLatestTag.tagName}' (verified via the release commit; the release body no longer carries the marker). Skipping.`,
+          );
+          module.clearCommits();
+          outcomes.push({
+            module,
+            action: 'skipped',
+            releaseTag: releaseForLatestTag.tagName,
+            release: releaseForLatestTag,
+          });
+          continue;
+        }
+      }
+
+      // Step 2: recover an orphan tag (a tag with no release) that this pull request produced — from a
+      // partial failure where the tag was pushed but the release was never created, or where the
+      // release was deleted by hand. The release is created for the existing tag, at its existing
+      // version, without bumping or pushing a new commit/tag.
+      //
+      // We search every orphan tag newest-first, not just the latest one, because a later pull request
+      // may already have bumped past ours: if PR #5's tag was orphaned and PR #6 then released a higher
+      // version, #5's orphan is no longer the latest and would otherwise never be healed (#5 would
+      // instead bump again and publish its older tree as the newest version). Only tags *without* a
+      // release are candidates, so in the steady state there is nothing to scan and no request is made.
+      // The scan is capped so a repository with many orphan tags cannot turn one merge into an
+      // unbounded number of lookups.
+      const orphanTags = module.tags.filter((tag) => !module.releases.some((release) => release.tagName === tag.name));
+      const orphanTagsToInspect = orphanTags.slice(0, MAX_ORPHAN_TAG_LOOKUPS);
+      if (orphanTags.length > orphanTagsToInspect.length) {
+        info(
+          `Module '${moduleName}' has ${orphanTags.length} tags without releases; only the newest ${MAX_ORPHAN_TAG_LOOKUPS} are checked for recovery.`,
+        );
+      }
+
+      let recoverableTag: string | null = null;
+      for (const tag of orphanTagsToInspect) {
+        if ((await getTagProvenance(tag.name, tag.commitSHA)) !== 'unknown') {
+          recoverableTag = tag.name;
+          break;
+        }
+      }
+
+      if (recoverableTag !== null) {
+        const recoveredVersion = TerraformModule.getVersionFromTag(recoverableTag) as string;
+        info(`Module '${moduleName}' has tag '${recoverableTag}' without a release. Creating the missing release.`);
+
+        const changelog = createTerraformModuleChangelogEntry(recoveredVersion, module.commitMessages);
+        const body = `${changelog}\n\n${releaseMarker}`;
+        const response = await octokit.rest.repos.createRelease({
+          owner,
+          repo,
+          tag_name: recoverableTag,
+          name: recoverableTag,
+          body,
+          draft: false,
+          prerelease: config.preRelease,
+        });
+
+        const release = {
+          id: response.data.id,
+          title: response.data.name ?? recoverableTag,
+          tagName: response.data.tag_name,
+          body: response.data.body ?? body,
+        };
+        module.setReleases([release, ...module.releases]);
+        module.clearCommits();
+        outcomes.push({ module, action: 'recovered', releaseTag: recoverableTag, release });
+        continue;
+      }
+
+      // Orphan tags we could NOT attribute to this pull request are deliberately left alone: they
+      // belong to a different pull request (or predate this action), and their owner's re-run is what
+      // should heal them. Claiming one would attach this pull request's notes to another commit's tree
+      // and leave this pull request's own changes unreleased.
+      if (orphanTagsToInspect.length > 0) {
+        const isSingle = orphanTagsToInspect.length === 1;
+        const tagList = orphanTagsToInspect.map((tag) => `'${tag.name}'`).join(', ');
+        warning(
+          `Module '${moduleName}' has ${isSingle ? 'a tag' : 'tags'} without a release (${tagList}) that ${isSingle ? 'was' : 'were'} not produced by this pull request. Leaving ${isSingle ? 'it' : 'them'} untouched and releasing a new version instead.`,
+        );
+      }
+
+      // Step 3: Normal release — bump the version, then commit, tag, push, and create the release.
       const releaseTag = module.getReleaseTag() as string;
       const releaseTagVersion = module.getReleaseTagVersion() as string;
-      info(`Processing module: ${moduleName}`);
       info(`Release type: ${module.getReleaseType()}`);
       info(`Next tag version: ${releaseTagVersion}`);
 
@@ -136,8 +393,18 @@ export async function createTaggedReleases(terraformModules: TerraformModule[]):
       // Copy the module's .git directory
       cpSync(join(workspaceDir, '.git'), join(tmpDir, '.git'), { recursive: true });
 
-      // Git operations: commit the changes and tag the release
-      const commitMessage = `${module.getReleaseTag()}\n\n${prTitle}\n\n${prBody}`.trim();
+      // Git operations: commit the changes and tag the release.
+      //
+      // The hidden marker is appended as the final line so this commit — and therefore the tag pointing
+      // at it — can later be proven to belong to this pull request. That proof is what makes step 2's
+      // orphan-tag recovery safe; without it we could not distinguish our own interrupted release from
+      // another pull request's, or from a tag pushed by hand.
+      //
+      // The title and body are untrusted and MUST be neutralized first. `git commit -m` uses
+      // `cleanup=whitespace`, so a marker planted on its own line in a pull request description would
+      // survive verbatim into the very text this provenance check trusts.
+      const commitMessage =
+        `${releaseTag}\n\n${neutralizePrMarkers(prTitle)}\n\n${neutralizePrMarkers(prBody)}\n\n${releaseMarker}`.trim();
       const gitPath = await which('git');
       const githubActionsBotEmail = await getGitHubActionsBotEmail();
 
@@ -163,7 +430,8 @@ export async function createTaggedReleases(terraformModules: TerraformModule[]):
 
       // Create a GitHub release using the tag
       info(`Creating GitHub release for ${moduleName}@${releaseTagVersion}`);
-      const body = createTerraformModuleChangelog(module);
+      const changelog = createTerraformModuleChangelog(module);
+      const body = `${changelog}\n\n${releaseMarker}`;
 
       const response = await octokit.rest.repos.createRelease({
         owner,
@@ -193,18 +461,26 @@ export async function createTaggedReleases(terraformModules: TerraformModule[]):
       // We also need to ensure that this module can't be released anymore. Thus, we need to clear existing commits
       // as this is the primary driver for determining release status.
       module.clearCommits();
+
+      outcomes.push({ module, action: 'created', releaseTag, release });
     }
 
-    return terraformModulesToRelease;
+    return outcomes;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
 
-    // Handle GitHub permissions or any error related to pushing tags
-    if (errorMessage.includes('The requested URL returned error: 403')) {
+    // Handle GitHub permissions or any error related to creating tags or releases. The git CLI reports a
+    // permissions failure in the push output, whereas the Releases API surfaces it as a 403 RequestError;
+    // match both so the remediation is shown either way.
+    const isPermissionsError =
+      errorMessage.includes('The requested URL returned error: 403') ||
+      (error instanceof RequestError && error.status === 403);
+
+    if (isPermissionsError) {
       throw new Error(
         [
-          `Failed to create tags in repository: ${errorMessage}.`,
-          'Ensure that the GitHub Actions workflow has the correct permissions to create tags.',
+          `Failed to create releases/tags in repository: ${errorMessage}.`,
+          'Ensure that the GitHub Actions workflow has the correct permissions to create tags and releases.',
           'Update your workflow YAML file with the following block under "permissions":',
           '\n\npermissions:\n  contents: write',
         ].join(' '),
@@ -212,7 +488,7 @@ export async function createTaggedReleases(terraformModules: TerraformModule[]):
       );
     }
 
-    throw new Error(`Failed to create tags in repository: ${errorMessage}`, { cause: error });
+    throw new Error(`Failed to create releases/tags in repository: ${errorMessage}`, { cause: error });
   } finally {
     console.timeEnd('Elapsed time pushing new tags & release');
     endGroup();

--- a/src/terraform-module.ts
+++ b/src/terraform-module.ts
@@ -253,7 +253,21 @@ export class TerraformModule {
       return null;
     }
 
-    const match = MODULE_TAG_REGEX.exec(latestTag);
+    return TerraformModule.getVersionFromTag(latestTag);
+  }
+
+  /**
+   * Extracts the version portion of a module tag, preserving any version prefix (such as "v").
+   *
+   * Static because the orphan-tag recovery path in `createTaggedReleases` needs the version of an
+   * arbitrary existing tag, not only the module's latest one.
+   *
+   * @param {string} tag - A module tag (e.g. `aws/vpc/v1.2.3`).
+   * @returns {string | null} The version including any prefix (e.g. `v1.2.3`), or null if the tag does
+   *  not match the expected module tag format.
+   */
+  public static getVersionFromTag(tag: string): string | null {
+    const match = MODULE_TAG_REGEX.exec(tag);
 
     return match ? match[3] : null;
   }

--- a/src/types/context.types.ts
+++ b/src/types/context.types.ts
@@ -51,6 +51,18 @@ export interface Context {
   workspaceDir: string;
 
   /**
+   * The branch this pull request targets (e.g. `main`). Used to determine whether the checked-out tree
+   * is still current before performing destructive merge steps.
+   */
+  baseRef: string;
+
+  /**
+   * The merge commit created when this pull request was merged, or `null` when the pull request is not
+   * merged (or GitHub has not yet computed it).
+   */
+  mergeCommitSha: string | null;
+
+  /**
    * Flag to indicate if the current event is a pull request merge event.
    */
   isPrMergeEvent: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,5 +19,8 @@ export * from './github.types';
 // Node:child_process types
 export * from './node-child-process.types';
 
+// Release and self-healing types
+export * from './release.types';
+
 // Wiki related types
 export * from './wiki.types';

--- a/src/types/release.types.ts
+++ b/src/types/release.types.ts
@@ -1,0 +1,93 @@
+import type { TerraformModule } from '@/terraform-module';
+import type { ReleaseType } from '@/types/common.types';
+import type { GitHubRelease } from '@/types/github.types';
+
+/**
+ * Release and self-healing related types
+ */
+
+/**
+ * What `createTaggedReleases()` actually did for a module on this run.
+ *
+ * - `created` — a new version was bumped, committed, tagged, pushed, and released (the normal path).
+ * - `recovered` — an existing tag produced by this pull request had no release (a partial failure, or
+ *   a release deleted by hand), so the missing release was created for that tag at its existing
+ *   version. No bump, no new tag.
+ * - `skipped` — this pull request had already released the module; nothing was created.
+ */
+export type ReleaseAction = 'created' | 'recovered' | 'skipped';
+
+/**
+ * The per-module result of `createTaggedReleases()`.
+ *
+ * This exists because "which modules were released" is no longer the whole story once releases are
+ * self-healing: on a re-run a module may be skipped or recovered rather than newly created, and the
+ * version that ends up published is then NOT the live-bumped `module.getReleaseTag()`. Consumers of
+ * the action's outputs and the post-release comment must both report the tag that actually exists.
+ */
+export interface ReleaseOutcome {
+  /**
+   * The module this outcome describes.
+   */
+  module: TerraformModule;
+
+  /**
+   * What was done for this module on this run.
+   */
+  action: ReleaseAction;
+
+  /**
+   * The tag that actually exists for this pull request's release of the module. For `created` this is
+   * the newly pushed tag; for `recovered` and `skipped` it is the pre-existing tag.
+   */
+  releaseTag: string;
+
+  /**
+   * The release attributed to this pull request — never simply the module's highest release.
+   */
+  release: GitHubRelease;
+}
+
+/**
+ * What happened to a changed module, as reported in the `changed-modules-map` action output.
+ *
+ * Extends {@link ReleaseAction} with `none`, meaning no release was attempted for the module on this
+ * run — because the legacy gate skipped the pull request, or because the module was withheld on a
+ * stale checkout. When the action is `none`, `releaseTag` is `null`: nothing was published.
+ */
+export type ChangedModuleAction = ReleaseAction | 'none';
+
+/**
+ * The per-module shape of the `changed-modules-map` action output.
+ *
+ * On a merge run this map is re-emitted after releases are created so `releaseTag` names a tag that
+ * actually exists rather than the optimistically computed next version. Consumers should branch on
+ * `action` before treating `releaseTag` as a newly published release.
+ */
+export interface ChangedModuleOutput {
+  /**
+   * The directory path of the module.
+   */
+  path: string;
+
+  /**
+   * The most recent git tag for the module prior to this run.
+   */
+  latestTag: string | null;
+
+  /**
+   * The tag associated with this pull request's release of the module, or `null` when nothing was
+   * published (`action: 'none'`).
+   */
+  releaseTag: string | null;
+
+  /**
+   * The computed release type (major, minor, patch).
+   */
+  releaseType: ReleaseType | null;
+
+  /**
+   * What the action actually did for this module. Only present on merge runs.
+   */
+  action?: ChangedModuleAction;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -92,7 +92,30 @@ export const GITHUB_ACTIONS_BOT_NAME = 'GitHub Actions';
 export const GITHUB_ACTIONS_BOT_USERNAME = 'github-actions[bot]';
 
 export const PR_SUMMARY_MARKER = '<!-- techpivot/terraform-module-releaser — pr-summary-marker -->';
-export const PR_RELEASE_MARKER = '<!-- techpivot/terraform-module-releaser — release-marker -->';
+
+/**
+ * Current post-release comment identity marker (written and read by this version of the action). The
+ * schema digit makes future changes detectable, and it is intentionally distinct from
+ * {@link LEGACY_PR_RELEASE_COMMENT_MARKER} so new and legacy post-release comments are trivially distinguishable.
+ */
+export const PR_RELEASE_COMMENT_MARKER = '<!-- techpivot/terraform-module-releaser:release:1 -->';
+
+/**
+ * The previous (pre-marker-scheme) post-release comment marker. READ-ONLY: never written by current
+ * code. The legacy gate in `createTaggedReleases` uses it to recognize pull requests that completed
+ * their release under an older version of the action, preserving the old "don't double-release"
+ * behavior without parsing editable release-note text.
+ */
+export const LEGACY_PR_RELEASE_COMMENT_MARKER = '<!-- techpivot/terraform-module-releaser — release-marker -->';
+
+/**
+ * Hidden, schema-versioned marker embedded in each release BODY this action creates, tying the release
+ * to the pull request that produced it. This is the durable idempotency key for self-healing releases:
+ * `createTaggedReleases` scans release bodies for it (version-agnostically) to decide what to (re)create.
+ * See `buildPrMarker` / `matchesPrMarker` in `src/utils/markers.ts`.
+ */
+export const RELEASE_BODY_PR_MARKER_PREFIX = '<!-- techpivot/terraform-module-releaser:release-pr:';
+export const RELEASE_BODY_PR_MARKER_SCHEMA = 1;
 
 export const PROJECT_URL = 'https://github.com/techpivot/terraform-module-releaser';
 

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -44,13 +44,9 @@ export function findModuleTerraformDocsConfig(moduleDirectory: string, workspace
       break;
     }
 
-    // Move to parent directory, but don't go above workspace root
-    const parentDir = dirname(currentDir);
-    /* c8 ignore next 3 -- unreachable: isWithinWorkspace guarantees resolvedWorkspaceDir is traversed before filesystem root */
-    if (parentDir === currentDir) {
-      break;
-    }
-    currentDir = parentDir;
+    // Move to the parent directory. The loop always breaks at the workspace root above (guaranteed by
+    // the isWithinWorkspace check), so we never need a filesystem-root guard and never walk past it.
+    currentDir = dirname(currentDir);
   }
 
   return null;

--- a/src/utils/freshness.ts
+++ b/src/utils/freshness.ts
@@ -1,0 +1,104 @@
+import { context } from '@/context';
+import { info, warning } from '@actions/core';
+
+/**
+ * Determines whether the checked-out workspace still represents the current tip of the base branch.
+ *
+ * **Why this exists.** The merge handler mixes two sources of truth. The set of Terraform modules is
+ * derived from the **checked-out tree** (`parseTerraformModules` walks `context.workspaceDir`), while
+ * tags and releases are fetched **live** from the API. That asymmetry is harmless on a normal merge,
+ * because the checkout *is* the current tree. It is destructive on a re-run of an older merged pull
+ * request: `actions/checkout` restores that pull request's merge commit, so every module added since is
+ * absent from the tree, and the cleanup step then classifies their tags and releases as orphaned and
+ * deletes them. Wiki regeneration has the same problem — it rewrites the wiki from the stale module
+ * list, removing pages for modules added later — and is not covered by `delete-legacy-tags`.
+ *
+ * Previously this was masked by an unconditional early-exit whenever a post-release comment existed.
+ * That exit was removed so that releases could self-heal, which is what exposed the hazard; releases
+ * are safe to re-run, but deletions computed from a stale tree are not.
+ *
+ * **Failure policy: fails open.** A null merge commit or any API error returns `true`, preserving the
+ * pre-existing behavior rather than silently disabling wiki generation and cleanup on a transient blip.
+ * The guard exists to prevent a rare, destructive mistake, not to become a new single point of failure.
+ *
+ * @returns {Promise<boolean>} `true` when the checkout is current (or freshness cannot be determined).
+ */
+export async function isCheckoutCurrent(): Promise<boolean> {
+  const {
+    octokit,
+    repo: { owner, repo },
+    baseRef,
+    mergeCommitSha,
+  } = context;
+
+  if (mergeCommitSha === null) {
+    warning(
+      "Unable to determine this pull request's merge commit; assuming the checkout is current. Obsolete tag/release cleanup and wiki regeneration will proceed.",
+    );
+    return true;
+  }
+
+  try {
+    const { data } = await octokit.rest.repos.compareCommitsWithBasehead({
+      owner,
+      repo,
+      basehead: `${mergeCommitSha}...${baseRef}`,
+    });
+
+    // 'identical' means the base branch tip is exactly this pull request's merge commit, so the tree we
+    // checked out is the current tree. Anything else ('ahead', 'behind', 'diverged') means it is not.
+    if (data.status === 'identical') {
+      return true;
+    }
+
+    info(
+      `Base branch '${baseRef}' has advanced ${data.ahead_by} commit(s) beyond this pull request's merge commit (${mergeCommitSha}); status: ${data.status}.`,
+    );
+
+    return false;
+  } catch (error) {
+    warning(
+      `Unable to compare this pull request's merge commit against '${baseRef}'; assuming the checkout is current: ${error instanceof Error ? error.message : String(error)}`,
+    );
+
+    return true;
+  }
+}
+
+/**
+ * Returns whether a repository-relative path still exists on the base branch.
+ *
+ * Used only on the stale-checkout path, to avoid "resurrecting" a module that was deleted by a later
+ * pull request. On a stale checkout such a module reappears in the tree with no tags (its tags were
+ * cleaned up when it was removed), which reads as a brand-new module and would otherwise be released
+ * afresh — and, because cleanup is skipped on that same run, the resurrected tag would survive.
+ *
+ * Fails open (`true`) on anything other than a definitive 404, so a transient error never silently
+ * suppresses a legitimate initial release.
+ *
+ * @param {string} relativePath - The module directory, relative to the workspace root.
+ * @returns {Promise<boolean>} Whether the path exists on the base branch.
+ */
+export async function pathExistsOnBaseRef(relativePath: string): Promise<boolean> {
+  const {
+    octokit,
+    repo: { owner, repo },
+    baseRef,
+  } = context;
+
+  try {
+    await octokit.rest.repos.getContent({ owner, repo, path: relativePath, ref: baseRef });
+
+    return true;
+  } catch (error) {
+    if ((error as { status?: number }).status === 404) {
+      return false;
+    }
+
+    warning(
+      `Unable to verify whether '${relativePath}' still exists on '${baseRef}'; assuming it does: ${error instanceof Error ? error.message : String(error)}`,
+    );
+
+    return true;
+  }
+}

--- a/src/utils/markers.ts
+++ b/src/utils/markers.ts
@@ -1,0 +1,177 @@
+import { context } from '@/context';
+import { RELEASE_BODY_PR_MARKER_PREFIX, RELEASE_BODY_PR_MARKER_SCHEMA } from '@/utils/constants';
+
+/**
+ * Escapes a string for safe literal use inside a regular expression.
+ *
+ * @param {string} value - The raw string to escape.
+ * @returns {string} The escaped string.
+ */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const ESCAPED_MARKER_PREFIX = escapeRegExp(RELEASE_BODY_PR_MARKER_PREFIX);
+
+/**
+ * Matches every marker that occupies a whole line, capturing its `<owner>/<repo>#<prNumber>` identity.
+ *
+ * Anchoring to a standalone line (tolerating CRLF from the API and surrounding horizontal whitespace)
+ * means a marker embedded mid-sentence inside attacker-influenced prose is never honored. Both writers
+ * always emit the marker as its own trailing line.
+ */
+const MARKER_LINE_REGEX = new RegExp(
+  `(?:^|\\r?\\n)[ \\t]*${ESCAPED_MARKER_PREFIX}\\d+:(\\S+#\\d+) -->[ \\t]*(?=\\r?\\n|$)`,
+  'g',
+);
+
+/**
+ * Returns the pull request identity this marker scheme uses: `<owner>/<repo>#<prNumber>`.
+ *
+ * The repository is part of the identity because a fork or mirror clone copies **tags but not
+ * releases**. Every module's latest tag in such a clone is therefore an orphan carrying the upstream
+ * marker, and fork pull request numbering restarts at 1 — so a bare number would let a fork adopt an
+ * upstream tag on a number collision.
+ *
+ * @param {number} prNumber - The pull request number.
+ * @returns {string} The scoped identity.
+ */
+function buildPrIdentity(prNumber: number): string {
+  const {
+    repo: { owner, repo },
+  } = context;
+
+  return `${owner}/${repo}#${prNumber}`;
+}
+
+/**
+ * Collects the distinct pull request identities carried by standalone marker lines in the given text.
+ *
+ * @param {string} text - The release body or commit message to scan.
+ * @returns {Set<string>} The distinct identities found.
+ */
+function collectMarkerIdentities(text: string): Set<string> {
+  const identities = new Set<string>();
+  for (const match of text.matchAll(MARKER_LINE_REGEX)) {
+    identities.add(match[1]);
+  }
+
+  return identities;
+}
+
+/**
+ * Builds the hidden, schema-versioned marker that ties a release — and the release commit its tag
+ * points at — to the pull request that produced it. The marker is an HTML comment so it never renders
+ * in release notes or in the wiki changelog.
+ *
+ * Format: `<!-- techpivot/terraform-module-releaser:release-pr:<schema>:<owner>/<repo>#<prNumber> -->`
+ *
+ * This is the single source of truth for the idempotency tie. Every writer (`createTaggedReleases`,
+ * which appends it to each release body it creates and to each release commit message) and the reader
+ * ({@link matchesPrMarker}) go through this module, so the two can never drift.
+ *
+ * @param {number} prNumber - The pull request number that produced the release.
+ * @returns {string} The hidden marker for that pull request.
+ */
+export function buildPrMarker(prNumber: number): string {
+  return `${RELEASE_BODY_PR_MARKER_PREFIX}${RELEASE_BODY_PR_MARKER_SCHEMA}:${buildPrIdentity(prNumber)} -->`;
+}
+
+/**
+ * Returns true if the given text carries this action's marker for the given pull request.
+ *
+ * Used against two kinds of text, which is why it is deliberately generic:
+ * - a **release body**, to detect that this pull request already released a module (step 1); and
+ * - a **release commit message**, to prove that an orphan tag was produced by this pull request
+ *   (step 2 provenance).
+ *
+ * Matching rules:
+ * - **Schema-agnostic** on the schema digit: a marker written by a future `:2:` schema is still
+ *   recognized by current code, and vice versa.
+ * - **Repository-scoped**, so a fork never mistakes an upstream tag for its own.
+ * - **Anchored to a standalone line**, so marker-shaped text inside prose is ignored.
+ * - **Ambiguity is not ownership.** If the text carries markers for more than one distinct pull
+ *   request, no match is reported. A single text should only ever name one producer; more than one
+ *   means something injected a marker, and the safe reading is "not ours" (which costs at most a
+ *   version bump, never a lost release).
+ *
+ * @param {string | undefined | null} text - The release body or commit message to test.
+ * @param {number} prNumber - The pull request number to match.
+ * @returns {boolean} Whether the text carries a marker for that pull request.
+ */
+export function matchesPrMarker(text: string | undefined | null, prNumber: number): boolean {
+  if (!text) {
+    return false;
+  }
+
+  const identities = collectMarkerIdentities(text);
+
+  return identities.size === 1 && identities.has(buildPrIdentity(prNumber));
+}
+
+/**
+ * Returns true if the given text carries one of our markers for ANY pull request.
+ *
+ * Used by the orphan-tag provenance check to distinguish "this tag predates the marker scheme"
+ * (no marker at all — eligible for the pre-marker fallback) from "this tag names some other pull
+ * request" (never adoptable, and no lookup needed).
+ *
+ * @param {string | undefined | null} text - The release body or commit message to test.
+ * @returns {boolean} Whether the text carries a marker for any pull request.
+ */
+export function hasAnyPrMarker(text: string | undefined | null): boolean {
+  if (!text) {
+    return false;
+  }
+
+  return collectMarkerIdentities(text).size > 0;
+}
+
+/**
+ * Returns true if `text` contains `marker` on a line of its own.
+ *
+ * Used for the fixed comment markers (`PR_SUMMARY_MARKER`, `PR_RELEASE_COMMENT_MARKER`), whose matches
+ * are acted on **destructively** — the newest match is edited in place and older ones are deleted. A
+ * bare `includes()` would also match a comment that merely *quotes* one of ours: GitHub's "Quote
+ * reply" copies raw markdown, hidden HTML comments included, so a reviewer quoting the action's
+ * comment would otherwise become the newest match and have their text overwritten.
+ *
+ * Quote-reply prefixes every line with `> `, so requiring the marker to start its own line (allowing
+ * only horizontal whitespace) excludes quoted copies while still matching our own comments, which
+ * always emit the marker as the first line. This deliberately does not filter on comment author,
+ * because consumers may run the action with a custom `github-token` whose comments are not authored by
+ * `github-actions[bot]`.
+ *
+ * @param {string | undefined | null} text - The comment body to test.
+ * @param {string} marker - The exact marker string to look for.
+ * @returns {boolean} Whether the marker occupies its own line.
+ */
+export function hasStandaloneMarkerLine(text: string | undefined | null, marker: string): boolean {
+  if (!text) {
+    return false;
+  }
+
+  return new RegExp(`(^|\\r?\\n)[ \\t]*${escapeRegExp(marker)}[ \\t]*(\\r?\\n|$)`).test(text);
+}
+
+/**
+ * Neutralizes any text that looks like one of our markers so untrusted input can never forge the
+ * idempotency tie or the provenance proof.
+ *
+ * Pull request titles and bodies, and commit messages, are interpolated verbatim into **release
+ * bodies** (`src/changelog.ts`) and into the **release commit message** (`createTaggedReleases`).
+ * Without this, a merged pull request whose description contained
+ * `<!-- techpivot/terraform-module-releaser:release-pr:1:owner/repo#123 -->` on its own line would
+ * plant that marker in a tag's commit message — the exact text the provenance check trusts — and could
+ * make pull request #123 adopt someone else's tag or skip its own release entirely.
+ *
+ * We escape only the opening `<` of our own marker namespace — unrelated HTML comments a user
+ * legitimately writes are left untouched. The escaped form renders visibly (rather than silently
+ * disappearing as a comment), which makes an attempted forgery obvious.
+ *
+ * @param {string} text - Untrusted text destined for a release body or a release commit message.
+ * @returns {string} The text with any marker-shaped sequences neutralized.
+ */
+export function neutralizePrMarkers(text: string): string {
+  return text.replaceAll(RELEASE_BODY_PR_MARKER_PREFIX, `&lt;${RELEASE_BODY_PR_MARKER_PREFIX.slice(1)}`);
+}

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -10,7 +10,7 @@ import { context } from '@/context';
 import { getExecErrorMessage, getModuleSource, renderTemplate } from '@/utils/string';
 import { generateTerraformDocs, installTerraformDocs } from '@/terraform-docs';
 import type { TerraformModule } from '@/terraform-module';
-import type { WikiGenerationResult, WikiStatusResult } from '@/types';
+import type { WikiGenerationResult, WikiStatus, WikiStatusResult } from '@/types';
 import {
   BRANDING_WIKI,
   GITHUB_ACTIONS_BOT_NAME,
@@ -32,6 +32,21 @@ import which from 'which';
 
 // Special subdirectory inside the primary repository where the wiki is checked out.
 const WIKI_SUBDIRECTORY_NAME = '.wiki';
+
+/**
+ * Returns true if a wiki status represents a failure (any `FAILURE_*` status).
+ *
+ * Centralizes the "did the wiki check fail?" decision so it cannot drift between call sites (the release
+ * plan comment header and the `hide-no-changes-pr-comment` nothing-to-report guard). The prefix check
+ * intentionally covers every current and future `FAILURE_*` status, so a newly added failure mode can
+ * never be silently treated as success (and have its error comment suppressed).
+ *
+ * @param {WikiStatus} status - The wiki status to evaluate.
+ * @returns {boolean} Whether the status is a failure.
+ */
+export function isWikiCheckFailure(status: WikiStatus): boolean {
+  return status.startsWith('FAILURE');
+}
 
 /**
  * Clones the wiki repository for the current GitHub repository into a specified subdirectory.


### PR DESCRIPTION
Replaces the blind early-exit that gated the whole merge handler on a post-release PR comment existing. That guard was the action's only state, it was editable by anyone with write access, and it made recovery impossible: deleting a release does not delete the comment, so a re-run exited and healed nothing. A run that died between pushing a tag and creating its release was equally unrecoverable.

createTaggedReleases() now converges per module instead of blindly creating:

  1.  release body carries this PR's marker          -> skip
  1b. latest tag is provably ours and released       -> skip (notes were edited)
  2.  an orphan tag is provably ours                 -> recreate its release at
                                                        that same version
  3.  otherwise                                      -> live-bump and release

Every release embeds a hidden, schema-versioned, repository-scoped marker tying it to the producing pull request -- in the release body and in the release commit message.

Provenance is the load-bearing part. An orphan tag is not proof of ownership: it may be hand-made, predate adoption of this action, or belong to another PR that crashed after pushing. Adopting one attaches this PR's changelog to another commit's tree and leaves this PR's own changes unreleased forever. The release commit message is immutable once pushed, so it is the authority.

Because that message is the oracle, the untrusted text baked into it is neutralized: git commit -m uses cleanup=whitespace, so a marker planted on its own line in a PR description would otherwise survive verbatim and let a crafted PR make another PR adopt its tag or skip its release. Marker matching is anchored to a standalone line, scoped by repository (a fork clones tags but not releases, and its PR numbers restart at 1), and text naming two different PRs is treated as naming neither.

For tags predating the marker, provenance falls back to the exact release commit shape -- line 1 is the tag, line 3 is the PR title -- not a substring test, because Renovate and Dependabot reuse titles byte-for-byte. That heuristic may recover an orphan but may never skip a release: a wrong skip drops a release forever, a wrong recovery is still re-runnable.

Step 2 searches every orphan tag newest-first, not only the latest, because a later PR may already have bumped past ours. Without that, re-running the older PR bumps again and publishes its stale tree as the module's newest version, silently reverting the newer one. Only tags without releases are candidates, so a healthy repo scans nothing; the scan is capped and logs when it truncates.

Removing the early-exit also exposed the destructive merge steps to stale checkouts, which is fixed here: obsolete tag/release cleanup and wiki regeneration derive their "what should exist" set from the checked-out tree while comparing against live tags, releases and wiki pages, so re-running an older merged PR deleted tags, releases and wiki pages for every module added since. delete-legacy-tags did not cover the wiki half. One compareCommitsWithBasehead call now detects a stale tree and skips both steps; it fails open. Modules that would be an initial release but no longer exist on the base branch are withheld so a deleted module is not resurrected, and every module bumped from a stale tree is named in a warning.

Also fixed:

- The legacy-comment check fails closed. Returning false was indistinguishable from "not legacy" and turned one transient 502 into an irreversible over-bump plus a duplicate release on a legacy PR.
- createTaggedReleases returns ReleaseOutcome[] rather than TerraformModule[]. The post-release comment reported releases[0] -- the module's highest release, which after a skip is a later PR's -- and rewrote this PR's own comment with the wrong version on every re-run. Outputs likewise advertised a bumped releaseTag that steps 1 and 2 never create; the merge path re-emits changed-modules-map with the tag that actually exists plus an additive `action` field (created | recovered | skipped | none), before the steps that can throw.
- The post-release comment is rebuilt from every release carrying this PR's marker, not just the modules processed on this run. A module released purely as an initial release loses needsRelease() once tagged, so a re-run silently dropped it from the comment and degraded the audit trail further each time.
- Destructive comment selection matches a standalone marker line. GitHub's "Quote reply" copies hidden HTML comments verbatim, so a reviewer quoting the action would otherwise become the newest match and have their comment overwritten and the action's own comment deleted.
- PR comments are read through one shared paginated helper at per_page 100. addReleasePlanComment read only the first page, so past 30 comments stale plan comments accumulated and the hide/minimize path silently stopped working.

Testing: adds an integration suite that drives the real run() repeatedly against a stateful in-memory GitHub fake, so one run's tags, releases, release commit messages and comments become the next run's input. Multi-run convergence was previously untestable -- every suite mocked one side of the releases/pull-request seam and asserted a single invocation -- and that is where the defects actually lived. It covers baseline, re-run convergence, initial-release comment fidelity, healing a deleted release, healing an orphan that is no longer latest, refusing hand-made and foreign-marker tags, marker forgery, the legacy gate, the stale-checkout guard and the resurrection guard. The shared Octokit mock now forwards params to createRelease, deleteRelease and the comment endpoints, which is what made stateful faking possible.

796 tests passing, 100% statement/branch/function/line coverage.