### PR TITLE
fix: resolve SonarQube code smells, harden commit parsing against ReDoS, and split lint CI

### DIFF
--- a/.claude/rules/tests.md
+++ b/.claude/rules/tests.md
@@ -18,3 +18,9 @@ Full guide: `docs/testing.md`. Global setup (`__tests__/_setup.ts`) auto-mocks `
 - Wiki fixtures in `__tests__/fixtures/` use Unicode filename characters (`∕` U+2215, `‒` U+2012) — preserve them
   exactly
 - Action inputs are driven by `INPUT_*` env vars via `setupTestInputs()`; defaults come from `action.yml` at test time
+- Use dedicated matchers — `toHaveLength(n)` not `.length` comparisons, `toBeInstanceOf(X)` / `.not.toBeInstanceOf(X)`
+  not `instanceof` booleans, `toBeNaN()` not `Number.isNaN` checks — they report clearer failures
+- Fold structurally identical tests into one `it.each` table with a descriptive `name`/`reason` field rendered via
+  `$name` in the title; keep tests with distinct setup or extra assertions separate
+- Declare hooks (`beforeEach`, `afterEach`, …) at the top of their `describe` scope, before any tests or nested
+  describes

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -60,9 +60,9 @@ jobs:
 
       # If `dist/` was different than expected, upload the expected version as a
       # workflow artifact.
-      - if: ${{ failure() && steps.diff.outcome == 'failure' }}
-        name: Upload Artifact
+      - name: Upload Artifact
         id: upload
+        if: ${{ failure() && steps.diff.outcome == 'failure' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint Codebase
+name: Lint
 
 on:
   pull_request:
@@ -18,10 +18,9 @@ env:
   GITLEAKS_VERSION: 8.30.1
 
 jobs:
-  lint:
-    name: Lint
+  format:
+    name: Format
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         id: checkout
@@ -40,35 +39,159 @@ jobs:
         id: npm-ci
         run: npm ci --no-fund
 
-      # Installed as binaries rather than via their GitHub Actions. actionlint publishes no action.yml at all.
-      # gitleaks-action is the paid product — the CLI is not — and it gates on GITLEAKS_LICENSE *before*
-      # scanning; since secrets are never exposed to workflows triggered from forked pull requests, that gate
-      # fails every external contribution with an error the contributor cannot fix. The CLI needs no license,
-      # so forks scan exactly like branches.
-      - name: Install external linters
-        id: install-external-linters
+      - name: Check Formatting
+        id: format-check
+        run: npm run format:check
+
+  code:
+    name: Code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        id: setup-node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install Dependencies
+        id: npm-ci
+        run: npm ci --no-fund
+
+      - name: Lint Code
+        id: lint-code
+        run: npm run lint:code
+
+  types:
+    name: Types
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        id: setup-node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install Dependencies
+        id: npm-ci
+        run: npm ci --no-fund
+
+      - name: Lint Types
+        id: lint-types
+        run: npm run lint:types
+
+  text:
+    name: Text
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        id: setup-node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install Dependencies
+        id: npm-ci
+        run: npm ci --no-fund
+
+      - name: Lint Text
+        id: lint-text
+        run: npm run lint:text
+
+  actions:
+    name: Actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        id: setup-node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install Dependencies
+        id: npm-ci
+        run: npm ci --no-fund
+
+      # Installed as a binary rather than via a GitHub Action — actionlint publishes no action.yml at all.
+      - name: Install actionlint
+        id: install-actionlint
         run: |
           curl -sSfL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
             | sudo tar -xz -C /usr/local/bin actionlint
+          actionlint --version
+
+      # `external-linter.mjs` turns a missing binary into a hard failure when CI is set, so a broken
+      # install step above can never look like a passing lint.
+      - name: Lint Actions
+        id: lint-actions
+        run: npm run lint:actions
+
+  secrets:
+    name: Secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Installed as a binary rather than via a GitHub Action. gitleaks-action is the paid product — the
+      # CLI is not — and it gates on GITLEAKS_LICENSE *before* scanning; since secrets are never exposed
+      # to workflows triggered from forked pull requests, that gate fails every external contribution with
+      # an error the contributor cannot fix. The CLI needs no license, so forks scan exactly like branches.
+      - name: Install gitleaks
+        id: install-gitleaks
+        run: |
           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             | sudo tar -xz -C /usr/local/bin gitleaks
-          actionlint --version
           gitleaks version
 
-      - name: Check formatting
-        id: format
-        run: npm run format:check
-
-      # Runs lint:code, lint:types, lint:text and lint:actions. `external-linter.mjs` turns a missing binary
-      # into a hard failure when CI is set, so a broken install step above can never look like a passing lint.
-      - name: Lint
-        id: lint
-        run: npm run lint
-
-      # Secret scanning is CI-only — it is not part of `npm run lint`, so contributors never need the binary.
-      # `dir` scans the whole working tree on every run, unlike the action's default of scanning only a pull
-      # request's own commit range, so a secret already sitting on main keeps failing CI until it is removed.
-      # Exclusions live in .gitleaks.toml.
-      - name: Scan for secrets
+      # Secret scanning is CI-only — it is not part of `npm run lint`, so contributors never need the
+      # binary. `dir` scans the whole working tree on every run, unlike the action's default of scanning
+      # only a pull request's own commit range, so a secret already sitting on main keeps failing CI until
+      # it is removed. Exclusions live in .gitleaks.toml.
+      - name: Scan for Secrets
         id: gitleaks
         run: gitleaks dir . --no-banner --redact
+
+  # Aggregate gate preserving the single "Lint" check name the previous one-job workflow exposed, so any
+  # branch-protection rule requiring "Lint" keeps working. Fails unless every lint job succeeded (a skipped
+  # or cancelled dependency is a failure here, closing the skipped-check loophole).
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: [format, code, types, text, actions, secrets]
+    if: always()
+    steps:
+      - name: Verify All Lint Jobs Passed
+        id: verify
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: exit 1

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -19,12 +19,13 @@ env:
 
 jobs:
   preview-release:
-    name: release
+    name: Preview Release
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required to read repo contents. Note: We leverage release-preview app for PR + commit generation
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # Get all history which is required for parsing commits
           persist-credentials: false
@@ -40,7 +41,7 @@ jobs:
         id: npm-ci
         run: npm ci --no-fund
 
-      - name: Validate version input
+      - name: Validate Version Input
         run: |
           # Ensure the provided version strictly matches X.Y.Z where X,Y,Z are numeric to avoid injection.
           if ! [[ '${{ env.VERSION }}' =~ ^[0-9]+(\.[0-9]+){2}$ ]]; then
@@ -48,15 +49,15 @@ jobs:
             exit 1
           fi
 
-      - name: Update package.json version
+      - name: Update package.json Version
         # Quote the value so the shell treats it as a single literal argument (prevents command/word splitting).
         # Flag order changed (options first) for clarity but either order works.
         run: npm version --no-git-tag-version '${{ env.VERSION }}'
 
-      - name: Build the package
+      - name: Build the Package
         run: npm run package
 
-      - name: Run Tests Typescript
+      - name: Run Tests
         run: npm run test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -65,7 +66,7 @@ jobs:
         run: npm run coverage
 
       # Ensure that the package.json is formatted correctly as result of the npm version command sorting keys
-      # differently from biome.continue-on-error:
+      # differently from biome
       - name: Format Fix
         run: npm run format
 
@@ -95,8 +96,9 @@ jobs:
       #
       # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
 
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      - name: Create GitHub App Token
         id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_PREVIEW_APP_ID }}
           private-key: ${{ secrets.RELEASE_PREVIEW_APP_PRIVATE_KEY }}
@@ -116,7 +118,7 @@ jobs:
 
       # Note: We can't change the head branch once a PR is opened. Thus we need to delete any branches
       # that exist from any existing open pull requests. (App Perm = Pull Request: Read + Write)
-      - name: Close existing release pull requests
+      - name: Close Existing Release Pull Requests
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   tag-and-release:
+    name: Tag and Release
     runs-on: ubuntu-latest
     permissions:
       contents: write # To publish tags and to publish GitHub release
@@ -18,13 +19,14 @@ jobs:
       github.event.pull_request.merged == true
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # Get all history
           fetch-tags: true
           persist-credentials: true
 
-      - name: Extract version from PR body
+      - name: Extract Version from PR Body
         id: extract-version
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -37,7 +39,7 @@ jobs:
             }
             throw new Error('Version not found in PR body');
 
-      - name: Extract release notes from PR body
+      - name: Extract Release Notes from PR Body
         id: extract-release-notes
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -55,7 +57,7 @@ jobs:
             console.log(releaseNotes);
             return releaseNotes;
 
-      - name: Create and push tag
+      - name: Create and Push Tag
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,43 +1,49 @@
 name: Test
 
 on:
-  # Trigger analysis when pushing in master or pull requests, and when creating
-  # a pull request.
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
 
 jobs:
-  Tests:
-    runs-on: ubuntu-latest
+  test:
     name: TypeScript Tests
-    permissions:
-      contents: read
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Disabling shallow clone is recommended for improving relevancy of reporting
+          # Disabling shallow clone is recommended for improving relevancy of SonarQube reporting
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup Node.js
+        id: setup-node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
           cache: npm
 
       - name: Install Dependencies
+        id: npm-ci
         run: npm ci --no-fund
 
-      - name: Run Tests Typescript
+      - name: Run Tests
+        id: test
         run: npm run test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Note: SonarQube requires the results from tests to get the coverage report
       - name: SonarQube Scan
+        id: sonarqube
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,20 @@ deliberately not part of `npm run lint`.
 - `@actions/core` + `@octokit` for GitHub integration; Vitest for tests
 - Path aliases: `@/` → `src/`, `@/tests/` → `__tests__/`, `@/mocks/` → `__mocks__/`
 
+## Code quality
+
+SonarQube scans every PR (`test.yml`); write to these conventions up front rather than fixing findings after:
+
+- Regexes must be linear-time — no adjacent quantifiers that can match the same characters (see `REVERT_PATTERN` in
+  `src/commit-analyzer.ts` for the canonical fix pattern and its regression test)
+- Prefer `??` over equivalent ternaries · `replaceAll` over global-regex `replace` · `.includes(x)` over equality
+  `.some()` · one multi-argument `push()` over consecutive pushes · `node:path` joins (`win32.join` for Windows-only
+  paths) over hand-escaped separators
+- Never default a parameter to a non-empty object literal — take `options?` and spread it over inline defaults:
+  `{ per_page: 100, page: 1, ...options }`
+- Validate at the boundary: input parsing rejects bad values (e.g. `NaN` from number inputs) with the input name in the
+  error, instead of letting them flow into config
+
 ## Architecture
 
 Runs on `pull_request` events with two flows: PR open/sync → parse modules, post release plan comment; PR merged →

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ SonarQube scans every PR (`test.yml`); write to these conventions up front rathe
   paths) over hand-escaped separators
 - Never default a parameter to a non-empty object literal — take `options?` and spread it over inline defaults:
   `{ per_page: 100, page: 1, ...options }`
-- Validate at the boundary: input parsing rejects bad values (e.g. `NaN` from number inputs) with the input name in the
+- Validate at the boundary: input parsing rejects bad values (e.g. non-integer number inputs) with the input name in the
   error, instead of letting them flow into config
 
 ## Architecture

--- a/__tests__/commit-analyzer.test.ts
+++ b/__tests__/commit-analyzer.test.ts
@@ -1,4 +1,5 @@
 import {
+  REVERT_PATTERN,
   computeReleaseType,
   detectConventionalCommitReleaseType,
   detectKeywordReleaseType,
@@ -176,22 +177,14 @@ describe('commit-analyzer', () => {
         });
       });
 
-      it('should return null for extra spaces around colon (not valid CC format)', () => {
-        // Conventional Commits spec requires type immediately followed by colon
-        const result = parseConventionalCommit('feat : extra space before colon');
-        expect(result).toBeNull();
-      });
-
-      it('should return null for no space after colon (not valid CC format)', () => {
-        // Conventional Commits spec requires a space after the colon
-        const result = parseConventionalCommit('feat:no space');
-        expect(result).toBeNull();
-      });
-
-      it('should return null for bang with no space after colon', () => {
-        // Even with bang indicator, space after colon is required
-        const result = parseConventionalCommit('feat!:no space after bang');
-        expect(result).toBeNull();
+      // The Conventional Commits spec requires the type to immediately touch the colon and the
+      // colon to be followed by a space — malformed spacing must not parse
+      it.each([
+        { reason: 'extra space before colon', message: 'feat : extra space before colon' },
+        { reason: 'no space after colon', message: 'feat:no space' },
+        { reason: 'bang with no space after colon', message: 'feat!:no space after bang' },
+      ])('should return null for $reason (not valid CC format)', ({ message }) => {
+        expect(parseConventionalCommit(message)).toBeNull();
       });
 
       it('should handle empty scope parentheses', () => {
@@ -299,28 +292,34 @@ describe('commit-analyzer', () => {
     });
 
     describe('non-conventional commit messages', () => {
-      it('should return null for plain text message', () => {
-        expect(parseConventionalCommit('update readme')).toBeNull();
+      it.each([
+        { reason: 'plain text message', message: 'update readme' },
+        { reason: 'message without colon', message: 'feat add new feature' },
+        { reason: 'empty string', message: '' },
+        { reason: 'message with only whitespace', message: '   ' },
+        { reason: 'merge commit', message: "Merge branch 'feature' into main" },
+        { reason: 'message with colon but no type', message: ': no type here' },
+      ])('should return null for $reason', ({ message }) => {
+        expect(parseConventionalCommit(message)).toBeNull();
+      });
+    });
+
+    describe('revert commit messages', () => {
+      it('should return null for a git-generated revert message (no conventional header)', () => {
+        expect(parseConventionalCommit('Revert "feat: add feature"\n\nThis reverts commit abc1234.')).toBeNull();
       });
 
-      it('should return null for message without colon', () => {
-        expect(parseConventionalCommit('feat add new feature')).toBeNull();
+      it('should extract the original header and hash from a revert message', () => {
+        const match = REVERT_PATTERN.exec('Revert "feat: add user endpoint"\n\nThis reverts commit abc1234.');
+        expect(match?.[1]).toBe('feat: add user endpoint');
+        expect(match?.[2]).toBe('abc1234');
       });
 
-      it('should return null for empty string', () => {
-        expect(parseConventionalCommit('')).toBeNull();
-      });
-
-      it('should return null for message with only whitespace', () => {
-        expect(parseConventionalCommit('   ')).toBeNull();
-      });
-
-      it('should return null for merge commit', () => {
-        expect(parseConventionalCommit("Merge branch 'feature' into main")).toBeNull();
-      });
-
-      it('should return null for message with colon but no type', () => {
-        expect(parseConventionalCommit(': no type here')).toBeNull();
+      it('should match revert-style messages in linear time (no catastrophic backtracking)', () => {
+        // Guards the linearized REVERT_PATTERN: the upstream preset pattern backtracks in O(n²)
+        // on long whitespace runs (≈14s on this input) and would blow the test timeout, while
+        // the linear pattern completes in under a millisecond.
+        expect(REVERT_PATTERN.test(`Revert "x${' '.repeat(100_000)}y`)).toBe(false);
       });
     });
 

--- a/__tests__/commit-analyzer.test.ts
+++ b/__tests__/commit-analyzer.test.ts
@@ -1,4 +1,5 @@
 import {
+  MAX_COMMIT_MESSAGE_PARSE_LENGTH,
   REVERT_PATTERN,
   computeReleaseType,
   detectConventionalCommitReleaseType,
@@ -320,6 +321,36 @@ describe('commit-analyzer', () => {
         // on long whitespace runs (≈14s on this input) and would blow the test timeout, while
         // the linear pattern completes in under a millisecond.
         expect(REVERT_PATTERN.test(`Revert "x${' '.repeat(100_000)}y`)).toBe(false);
+      });
+    });
+
+    describe('pathological and oversized messages', () => {
+      it('should parse a long line without issue references quickly (issue-references regex disabled)', () => {
+        // With the library-default issuePrefixes, the reference-parts regex took ~10 seconds on
+        // this input; a regression re-enabling it shows up here as a test timeout.
+        const result = parseConventionalCommit(`fix: y\n\n${' '.repeat(2_000)}y`);
+        expect(result).toEqual({ type: 'fix', scope: null, breaking: false, description: 'y' });
+      });
+
+      it('should parse a message far beyond the parse cap quickly', () => {
+        const result = parseConventionalCommit(`feat: x\n\n${' '.repeat(100_000)}y`);
+        expect(result).toEqual({ type: 'feat', scope: null, breaking: false, description: 'x' });
+      });
+
+      it('should preserve a breaking-change footer that sits beyond the parse cap', () => {
+        const filler = 'x'.repeat(MAX_COMMIT_MESSAGE_PARSE_LENGTH);
+        const result = parseConventionalCommit(`feat(api): add endpoint\n\n${filler}\n\nBREAKING CHANGE: drop v1`);
+        expect(result).toEqual({ type: 'feat', scope: 'api', breaking: true, description: 'add endpoint' });
+      });
+
+      it('should preserve the header breaking indicator for oversized messages', () => {
+        const result = parseConventionalCommit(`fix!: patch\n\n${'x'.repeat(MAX_COMMIT_MESSAGE_PARSE_LENGTH)}`);
+        expect(result).toEqual({ type: 'fix', scope: null, breaking: true, description: 'patch' });
+      });
+
+      it('should still parse messages containing issue references normally', () => {
+        const result = parseConventionalCommit('fix: y\n\nFixes #123');
+        expect(result).toEqual({ type: 'fix', scope: null, breaking: false, description: 'y' });
       });
     });
 

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -173,11 +173,15 @@ describe('config', () => {
       }
     });
 
-    it('should throw error for non-numeric wiki-sidebar-changelog-max', () => {
-      setupTestInputs({ 'wiki-sidebar-changelog-max': 'invalid' });
-      // Rejected at input-parse time by createConfigFromInputs, before config-level validation runs
+    // Rejected at input-parse time by createConfigFromInputs, before config-level validation runs
+    it.each([
+      { reason: 'non-numeric', value: 'invalid' },
+      { reason: 'trailing-garbage', value: '123abc' },
+      { reason: 'non-integer', value: '1.5' },
+    ])('should throw error for $reason wiki-sidebar-changelog-max', ({ value }) => {
+      setupTestInputs({ 'wiki-sidebar-changelog-max': value });
       expect(() => getConfig()).toThrow(
-        new Error("Failed to process input 'wiki-sidebar-changelog-max': Invalid number value: 'invalid'"),
+        new Error(`Failed to process input 'wiki-sidebar-changelog-max': Invalid integer value: '${value}'`),
       );
     });
 

--- a/__tests__/config.test.ts
+++ b/__tests__/config.test.ts
@@ -175,8 +175,9 @@ describe('config', () => {
 
     it('should throw error for non-numeric wiki-sidebar-changelog-max', () => {
       setupTestInputs({ 'wiki-sidebar-changelog-max': 'invalid' });
+      // Rejected at input-parse time by createConfigFromInputs, before config-level validation runs
       expect(() => getConfig()).toThrow(
-        new TypeError('Wiki Sidebar Change Log Max must be an integer greater than or equal to one'),
+        new Error("Failed to process input 'wiki-sidebar-changelog-max': Invalid number value: 'invalid'"),
       );
     });
 

--- a/__tests__/devcontainer.test.ts
+++ b/__tests__/devcontainer.test.ts
@@ -45,7 +45,7 @@ const devMajor = Number(/^(\d+)/.exec(nodeVersionFile)?.[1]);
 describe('node version alignment', () => {
   it('should declare a nodeXX production runtime in action.yml', () => {
     expect(actionYml.runs.using).toMatch(/^node\d+$/);
-    expect(Number.isNaN(runtimeMajor)).toBe(false);
+    expect(runtimeMajor).not.toBeNaN();
   });
 
   it('should pin the engines.node floor to the production runtime major', () => {

--- a/__tests__/pull-request.test.ts
+++ b/__tests__/pull-request.test.ts
@@ -315,9 +315,9 @@ describe('pull-request', () => {
       try {
         await getPullRequestCommits();
       } catch (error) {
-        expect(error instanceof Error).toBe(true);
+        expect(error).toBeInstanceOf(Error);
         expect((error as Error).message).toBe(expectedErrorString);
-        expect((error as Error).cause instanceof RequestError).toBe(false);
+        expect((error as Error).cause).not.toBeInstanceOf(RequestError);
       }
     });
   });
@@ -840,9 +840,9 @@ describe('pull-request', () => {
       try {
         await addReleasePlanComment([], [], [], { status: WIKI_STATUS.SUCCESS });
       } catch (error) {
-        expect(error instanceof Error).toBe(true);
+        expect(error).toBeInstanceOf(Error);
         expect((error as Error).message).toBe(expectedErrorString);
-        expect((error as Error).cause instanceof RequestError).toBe(false);
+        expect((error as Error).cause).not.toBeInstanceOf(RequestError);
       }
 
       vi.mocked(context.octokit.rest.issues.createComment).mockImplementationOnce(() => {
@@ -852,9 +852,9 @@ describe('pull-request', () => {
       try {
         await addReleasePlanComment([], [], [], { status: WIKI_STATUS.SUCCESS });
       } catch (error) {
-        expect(error instanceof Error).toBe(true);
+        expect(error).toBeInstanceOf(Error);
         expect((error as Error).message).toBe(expectedErrorString);
-        expect((error as Error).cause instanceof Error).toBe(true);
+        expect((error as Error).cause).toBeInstanceOf(Error);
       }
     });
   });
@@ -1162,9 +1162,9 @@ describe('pull-request', () => {
       try {
         await addPostReleaseComment(releasedOutcomes);
       } catch (error) {
-        expect(error instanceof Error).toBe(true);
+        expect(error).toBeInstanceOf(Error);
         expect((error as Error).message).toBe(expectedErrorString);
-        expect((error as Error).cause instanceof RequestError).toBe(false);
+        expect((error as Error).cause).not.toBeInstanceOf(RequestError);
       }
 
       vi.mocked(context.octokit.rest.issues.createComment).mockImplementationOnce(() => {
@@ -1174,9 +1174,9 @@ describe('pull-request', () => {
       try {
         await addPostReleaseComment(releasedOutcomes);
       } catch (error) {
-        expect(error instanceof Error).toBe(true);
+        expect(error).toBeInstanceOf(Error);
         expect((error as Error).message).toBe(expectedErrorString);
-        expect((error as Error).cause instanceof RequestError).toBe(false);
+        expect((error as Error).cause).not.toBeInstanceOf(RequestError);
       }
     });
 

--- a/__tests__/releases.test.ts
+++ b/__tests__/releases.test.ts
@@ -82,7 +82,7 @@ describe('releases', () => {
     });
 
     it('should fetch releases and match expected structure', () => {
-      expect(Array.isArray(releases)).toBe(true);
+      expect(releases).toBeInstanceOf(Array);
       expect(releases.length).toBeGreaterThan(0);
 
       // Test initial release (v1.0.0)
@@ -132,8 +132,8 @@ describe('releases', () => {
       stubOctokitReturnData('repos.listReleases', mockListReleasesResponse);
       const releases = await getAllReleases({ per_page: 1 });
 
-      expect(Array.isArray(releases)).toBe(true);
-      expect(releases.length).toBe(mockListReleasesResponse.data.length);
+      expect(releases).toBeInstanceOf(Array);
+      expect(releases).toHaveLength(mockListReleasesResponse.data.length);
 
       // Exact match of known tags to ensure no unexpected tags are included
       expect(releases).toEqual(mockGetAllReleasesResponse);
@@ -157,8 +157,8 @@ describe('releases', () => {
       stubOctokitReturnData('repos.listReleases', mockReleaseDataSingle);
       const releases = await getAllReleases({ per_page: 1 });
 
-      expect(Array.isArray(releases)).toBe(true);
-      expect(releases.length).toBe(1);
+      expect(releases).toBeInstanceOf(Array);
+      expect(releases).toHaveLength(1);
 
       // Exact match of known tags to ensure no unexpected tags are included
       expect(releases).toEqual(mappedReleaseDataSingle);
@@ -175,8 +175,8 @@ describe('releases', () => {
       stubOctokitReturnData('repos.listReleases', mockListReleasesResponse);
       const releases = await getAllReleases({ per_page: 20 });
 
-      expect(Array.isArray(releases)).toBe(true);
-      expect(releases.length).toBe(mockListReleasesResponse.data.length);
+      expect(releases).toBeInstanceOf(Array);
+      expect(releases).toHaveLength(mockListReleasesResponse.data.length);
 
       // Exact match of known tags to ensure no unexpected tags are included
       expect(releases).toEqual(mockGetAllReleasesResponse);
@@ -202,7 +202,7 @@ describe('releases', () => {
       });
       const releases = await getAllReleases({ per_page: 1 });
 
-      expect(Array.isArray(releases)).toBe(true);
+      expect(releases).toBeInstanceOf(Array);
       expect(releases).toEqual([
         {
           id: 182147836,
@@ -238,7 +238,7 @@ describe('releases', () => {
       try {
         await getAllReleases();
       } catch (error) {
-        expect(error instanceof Error).toBe(true);
+        expect(error).toBeInstanceOf(Error);
         expect((error as Error).message).toBe(`Failed to fetch releases: ${errorMessage} (status: 403)`);
         expect((error as Error).cause).toBeInstanceOf(RequestError);
         expect(((error as Error).cause as RequestError).message).toBe(errorMessage);
@@ -261,7 +261,7 @@ describe('releases', () => {
       try {
         await getAllReleases();
       } catch (error) {
-        expect(error instanceof Error).toBe(true);
+        expect(error).toBeInstanceOf(Error);
         expect((error as Error).message).toBe(`Failed to fetch releases: ${errorMessage}`);
         expect((error as Error).cause).toBeInstanceOf(Error);
         expect(((error as Error).cause as Error).message).toBe(errorMessage);
@@ -285,7 +285,7 @@ describe('releases', () => {
       try {
         await getAllReleases();
       } catch (error) {
-        expect(error instanceof Error).toBe(true);
+        expect(error).toBeInstanceOf(Error);
         expect((error as Error).message).toBe(errorMessage.trim());
         expect((error as Error).cause).toBe(errorMessage);
       }
@@ -566,7 +566,7 @@ describe('releases', () => {
       try {
         await createTaggedReleases([mockTerraformModule]);
       } catch (error) {
-        expect(error instanceof Error).toBe(true);
+        expect(error).toBeInstanceOf(Error);
         expect((error as Error).message).toBe(`Failed to create releases/tags in repository: ${errorMessage}`);
         expect(((error as Error).cause as Error).message).toBe(errorMessage);
       }

--- a/__tests__/tags.test.ts
+++ b/__tests__/tags.test.ts
@@ -27,7 +27,7 @@ describe('tags', () => {
     it('should successfully fetch tags from the real repository', async () => {
       const tags = await getAllTags();
 
-      expect(Array.isArray(tags)).toBe(true);
+      expect(tags).toBeInstanceOf(Array);
 
       // Extract tag names from the tag objects
       const tagNames = tags.map((tag) => tag.name);
@@ -89,8 +89,8 @@ describe('tags', () => {
       stubOctokitReturnData('repos.listTags', mockTagData);
       const tags = await getAllTags({ per_page: 1 });
 
-      expect(Array.isArray(tags)).toBe(true);
-      expect(tags.length).toBe(3);
+      expect(tags).toBeInstanceOf(Array);
+      expect(tags).toHaveLength(3);
 
       // Exact match of known tags to ensure no unexpected tags are included
       expect(tags).toEqual(expectedTags);
@@ -111,8 +111,8 @@ describe('tags', () => {
       stubOctokitReturnData('repos.listTags', mockTagData);
       const tags = await getAllTags({ per_page: 1 });
 
-      expect(Array.isArray(tags)).toBe(true);
-      expect(tags.length).toBe(1);
+      expect(tags).toBeInstanceOf(Array);
+      expect(tags).toHaveLength(1);
 
       // Exact match of known tags to ensure no unexpected tags are included
       expect(tags).toEqual(expectedTags);
@@ -136,8 +136,8 @@ describe('tags', () => {
 
       const tags = await getAllTags({ per_page: 20 });
 
-      expect(Array.isArray(tags)).toBe(true);
-      expect(tags.length).toBe(3);
+      expect(tags).toBeInstanceOf(Array);
+      expect(tags).toHaveLength(3);
 
       // Exact match of known tags to ensure no unexpected tags are included
       const expectedTags = ['v2.0.0', 'v2.0.1', 'v2.0.2'];
@@ -172,7 +172,7 @@ describe('tags', () => {
       try {
         await getAllTags();
       } catch (error) {
-        expect(error instanceof Error).toBe(true);
+        expect(error).toBeInstanceOf(Error);
         expect((error as Error).message).toBe(`Failed to fetch tags: ${errorMessage} (status: 403)`);
         expect((error as Error).cause).toBeInstanceOf(RequestError);
         expect(((error as Error).cause as RequestError).message).toBe(errorMessage);
@@ -192,7 +192,7 @@ describe('tags', () => {
       try {
         await getAllTags();
       } catch (error) {
-        expect(error instanceof Error).toBe(true);
+        expect(error).toBeInstanceOf(Error);
         expect((error as Error).message).toBe(`Failed to fetch tags: ${errorMessage}`);
         expect((error as Error).cause).toBeInstanceOf(Error);
         expect(((error as Error).cause as Error).message).toBe(errorMessage);
@@ -213,7 +213,7 @@ describe('tags', () => {
       try {
         await getAllTags();
       } catch (error) {
-        expect(error instanceof Error).toBe(true);
+        expect(error).toBeInstanceOf(Error);
         expect((error as Error).message).toBe(errorMessage.trim());
         expect((error as Error).cause).toBe(errorMessage);
       }

--- a/__tests__/terraform-module.test.ts
+++ b/__tests__/terraform-module.test.ts
@@ -810,37 +810,19 @@ describe('TerraformModule', () => {
         expect(module.getReleaseTagVersion()).toBe('v0.1.0');
       });
 
-      it('should increment major version correctly', () => {
+      it.each([
+        { level: 'major', message: 'BREAKING CHANGE: major update', expected: 'v2.0.0' },
+        { level: 'minor', message: 'feat: new feature', expected: 'v1.3.0' },
+        { level: 'patch', message: 'fix: bug fix', expected: 'v1.2.4' },
+      ])('should increment $level version correctly', ({ message, expected }) => {
         module.setTags(createMockTags(['tf-modules/test-module/v1.2.3']));
         module.addCommit({
           sha: 'abc123',
-          message: 'BREAKING CHANGE: major update',
+          message,
           files: ['main.tf'],
         });
 
-        expect(module.getReleaseTagVersion()).toBe('v2.0.0');
-      });
-
-      it('should increment minor version correctly', () => {
-        module.setTags(createMockTags(['tf-modules/test-module/v1.2.3']));
-        module.addCommit({
-          sha: 'abc123',
-          message: 'feat: new feature',
-          files: ['main.tf'],
-        });
-
-        expect(module.getReleaseTagVersion()).toBe('v1.3.0');
-      });
-
-      it('should increment patch version correctly', () => {
-        module.setTags(createMockTags(['tf-modules/test-module/v1.2.3']));
-        module.addCommit({
-          sha: 'abc123',
-          message: 'fix: bug fix',
-          files: ['main.tf'],
-        });
-
-        expect(module.getReleaseTagVersion()).toBe('v1.2.4');
+        expect(module.getReleaseTagVersion()).toBe(expected);
       });
 
       it('should return null when no release is needed', () => {

--- a/__tests__/utils/file.test.ts
+++ b/__tests__/utils/file.test.ts
@@ -501,7 +501,7 @@ describe('utils/file', () => {
 
       expect(() => {
         const result = findTerraformModuleDirectories(tmpDir);
-        expect(Array.isArray(result)).toBe(true);
+        expect(result).toBeInstanceOf(Array);
       }).not.toThrow();
     });
   });
@@ -841,7 +841,7 @@ describe('utils/file', () => {
       copyModuleContents(srcDirectory, destDirectory, excludePatterns);
 
       // Validate that the destination directory is still empty
-      expect(readdirSync(destDirectory).length).toBe(0);
+      expect(readdirSync(destDirectory)).toHaveLength(0);
     });
 
     it('should throw an error if the source directory does not exist', () => {
@@ -938,7 +938,7 @@ describe('utils/file', () => {
       removeDirectoryContents(directory, exceptions);
 
       // Validate that the directory is still empty
-      expect(readdirSync(directory).length).toBe(0);
+      expect(readdirSync(directory)).toHaveLength(0);
     });
 
     it('should not remove if only exceptions are present', () => {
@@ -951,7 +951,7 @@ describe('utils/file', () => {
       removeDirectoryContents(directory, exceptions);
 
       expect(existsSync(join(directory, 'file.txt'))).toBe(true);
-      expect(readdirSync(directory).length).toBe(1); // Only the exception should exist
+      expect(readdirSync(directory)).toHaveLength(1); // Only the exception should exist
     });
 
     it('should handle nested exceptions correctly', () => {

--- a/__tests__/utils/string.test.ts
+++ b/__tests__/utils/string.test.ts
@@ -99,151 +99,134 @@ describe('utils/string', () => {
   });
 
   describe('renderTemplate', () => {
-    it('should replace a single placeholder', () => {
-      const template = 'Hello, {{name}}!';
-      const variables = { name: 'World' };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('Hello, World!');
-    });
+    const renderTemplateCases: Array<{
+      name: string;
+      template: string;
+      variables: Record<string, string | undefined | null>;
+      expected: string;
+    }> = [
+      // Basic replacement
+      {
+        name: 'replaces a single placeholder',
+        template: 'Hello, {{name}}!',
+        variables: { name: 'World' },
+        expected: 'Hello, World!',
+      },
+      {
+        name: 'replaces multiple placeholders',
+        template: '{{greeting}}, {{name}}!',
+        variables: { greeting: 'Hi', name: 'There' },
+        expected: 'Hi, There!',
+      },
+      {
+        name: 'handles templates with no placeholders',
+        template: 'Just a plain string.',
+        variables: { name: 'World' },
+        expected: 'Just a plain string.',
+      },
+      { name: 'handles empty string values', template: 'A{{key}}B', variables: { key: '' }, expected: 'AB' },
+      {
+        name: 'leaves unmapped placeholders untouched',
+        template: 'Hello, {{name}} and {{unmapped}}!',
+        variables: { name: 'World' },
+        expected: 'Hello, World and {{unmapped}}!',
+      },
+      {
+        name: 'handles complex templates with multiple variables',
+        template: 'Module: {{module}}, Version: {{version}}, Author: {{author}}',
+        variables: { module: 'vpc-endpoint', version: '1.0.0', author: 'TechPivot' },
+        expected: 'Module: vpc-endpoint, Version: 1.0.0, Author: TechPivot',
+      },
+      {
+        name: 'handles numeric values as strings',
+        template: 'Port: {{port}}, Count: {{count}}',
+        variables: { port: '8080', count: '3' },
+        expected: 'Port: 8080, Count: 3',
+      },
+      {
+        name: 'handles special characters in values',
+        template: 'Path: {{path}}, Command: {{cmd}}',
+        variables: { path: '/opt/bin/terraform', cmd: 'terraform init -backend=false' },
+        expected: 'Path: /opt/bin/terraform, Command: terraform init -backend=false',
+      },
+      { name: 'handles empty template', template: '', variables: { name: 'World' }, expected: '' },
+      {
+        name: 'handles empty variables object',
+        template: 'Hello, {{name}}!',
+        variables: {},
+        expected: 'Hello, {{name}}!',
+      },
+      {
+        name: 'handles placeholders with different casing',
+        template: 'Hello, {{Name}} and {{NAME}}!',
+        variables: { Name: 'World', NAME: 'UNIVERSE' },
+        expected: 'Hello, World and UNIVERSE!',
+      },
+      {
+        name: 'handles placeholders with numbers',
+        template: 'Item {{item1}} and {{item2}}',
+        variables: { item1: 'first', item2: 'second' },
+        expected: 'Item first and second',
+      },
+      // Undefined and null values leave placeholders unchanged
+      {
+        name: 'leaves placeholders with undefined values unchanged',
+        template: 'Hello, {{name}} and {{greeting}}!',
+        variables: { name: 'World', greeting: undefined },
+        expected: 'Hello, World and {{greeting}}!',
+      },
+      {
+        name: 'leaves all placeholders unchanged when every value is undefined',
+        template: '{{greeting}}, {{name}}!',
+        variables: { greeting: undefined, name: undefined },
+        expected: '{{greeting}}, {{name}}!',
+      },
+      {
+        name: 'handles mixed defined and undefined values',
+        template: 'Module: {{module}}, Version: {{version}}, Author: {{author}}',
+        variables: { module: 'vpc-endpoint', version: undefined, author: 'TechPivot' },
+        expected: 'Module: vpc-endpoint, Version: {{version}}, Author: TechPivot',
+      },
+      {
+        name: 'distinguishes empty string from undefined',
+        template: 'A{{key1}}B{{key2}}C',
+        variables: { key1: '', key2: undefined },
+        expected: 'AB{{key2}}C',
+      },
+      {
+        name: 'handles undefined values in complex templates',
+        template: 'Path: {{path}}, Command: {{cmd}}, Options: {{opts}}',
+        variables: { path: '/opt/bin/terraform', cmd: undefined, opts: '--verbose' },
+        expected: 'Path: /opt/bin/terraform, Command: {{cmd}}, Options: --verbose',
+      },
+      {
+        name: 'leaves placeholders with null values unchanged',
+        template: 'Hello, {{name}} and {{greeting}}!',
+        variables: { name: 'World', greeting: null },
+        expected: 'Hello, World and {{greeting}}!',
+      },
+      {
+        name: 'leaves all placeholders unchanged when every value is null',
+        template: '{{greeting}}, {{name}}!',
+        variables: { greeting: null, name: null },
+        expected: '{{greeting}}, {{name}}!',
+      },
+      {
+        name: 'handles mixed null, undefined, and defined values',
+        template: 'Module: {{module}}, Version: {{version}}, Author: {{author}}, License: {{license}}',
+        variables: { module: 'vpc-endpoint', version: null, author: 'TechPivot', license: undefined },
+        expected: 'Module: vpc-endpoint, Version: {{version}}, Author: TechPivot, License: {{license}}',
+      },
+      {
+        name: 'distinguishes empty string from null and undefined',
+        template: 'A{{key1}}B{{key2}}C{{key3}}D',
+        variables: { key1: '', key2: null, key3: undefined },
+        expected: 'AB{{key2}}C{{key3}}D',
+      },
+    ];
 
-    it('should replace multiple placeholders', () => {
-      const template = '{{greeting}}, {{name}}!';
-      const variables = { greeting: 'Hi', name: 'There' };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('Hi, There!');
-    });
-
-    it('should handle templates with no placeholders', () => {
-      const template = 'Just a plain string.';
-      const variables = { name: 'World' };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('Just a plain string.');
-    });
-
-    it('should handle empty string values', () => {
-      const template = 'A{{key}}B';
-      const variables = { key: '' };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('AB');
-    });
-
-    it('should leave unmapped placeholders untouched', () => {
-      const template = 'Hello, {{name}} and {{unmapped}}!';
-      const variables = { name: 'World' };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('Hello, World and {{unmapped}}!');
-    });
-
-    it('should handle complex templates with multiple variables', () => {
-      const template = 'Module: {{module}}, Version: {{version}}, Author: {{author}}';
-      const variables = { module: 'vpc-endpoint', version: '1.0.0', author: 'TechPivot' };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('Module: vpc-endpoint, Version: 1.0.0, Author: TechPivot');
-    });
-
-    it('should handle numeric values as strings', () => {
-      const template = 'Port: {{port}}, Count: {{count}}';
-      const variables = { port: '8080', count: '3' };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('Port: 8080, Count: 3');
-    });
-
-    it('should handle special characters in values', () => {
-      const template = 'Path: {{path}}, Command: {{cmd}}';
-      const variables = { path: '/opt/bin/terraform', cmd: 'terraform init -backend=false' };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('Path: /opt/bin/terraform, Command: terraform init -backend=false');
-    });
-
-    it('should handle empty template', () => {
-      const template = '';
-      const variables = { name: 'World' };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('');
-    });
-
-    it('should handle empty variables object', () => {
-      const template = 'Hello, {{name}}!';
-      const variables = {};
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('Hello, {{name}}!');
-    });
-
-    it('should handle placeholders with different casing', () => {
-      const template = 'Hello, {{Name}} and {{NAME}}!';
-      const variables = { Name: 'World', NAME: 'UNIVERSE' };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('Hello, World and UNIVERSE!');
-    });
-
-    it('should handle placeholders with numbers', () => {
-      const template = 'Item {{item1}} and {{item2}}';
-      const variables = { item1: 'first', item2: 'second' };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('Item first and second');
-    });
-
-    it('should handle undefined values by leaving placeholders unchanged', () => {
-      const template = 'Hello, {{name}} and {{greeting}}!';
-      const variables = { name: 'World', greeting: undefined };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('Hello, World and {{greeting}}!');
-    });
-
-    it('should handle all undefined values', () => {
-      const template = '{{greeting}}, {{name}}!';
-      const variables = { greeting: undefined, name: undefined };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('{{greeting}}, {{name}}!');
-    });
-
-    it('should handle mixed defined and undefined values', () => {
-      const template = 'Module: {{module}}, Version: {{version}}, Author: {{author}}';
-      const variables = { module: 'vpc-endpoint', version: undefined, author: 'TechPivot' };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('Module: vpc-endpoint, Version: {{version}}, Author: TechPivot');
-    });
-
-    it('should handle empty string vs undefined distinction', () => {
-      const template = 'A{{key1}}B{{key2}}C';
-      const variables = { key1: '', key2: undefined };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('AB{{key2}}C');
-    });
-
-    it('should handle undefined values in complex templates', () => {
-      const template = 'Path: {{path}}, Command: {{cmd}}, Options: {{opts}}';
-      const variables = { path: '/opt/bin/terraform', cmd: undefined, opts: '--verbose' };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('Path: /opt/bin/terraform, Command: {{cmd}}, Options: --verbose');
-    });
-
-    it('should handle null values by leaving placeholders unchanged', () => {
-      const template = 'Hello, {{name}} and {{greeting}}!';
-      const variables = { name: 'World', greeting: null };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('Hello, World and {{greeting}}!');
-    });
-
-    it('should handle all null values', () => {
-      const template = '{{greeting}}, {{name}}!';
-      const variables = { greeting: null, name: null };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('{{greeting}}, {{name}}!');
-    });
-
-    it('should handle mixed null, undefined, and defined values', () => {
-      const template = 'Module: {{module}}, Version: {{version}}, Author: {{author}}, License: {{license}}';
-      const variables = { module: 'vpc-endpoint', version: null, author: 'TechPivot', license: undefined };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('Module: vpc-endpoint, Version: {{version}}, Author: TechPivot, License: {{license}}');
-    });
-
-    it('should handle empty string vs null vs undefined distinction', () => {
-      const template = 'A{{key1}}B{{key2}}C{{key3}}D';
-      const variables = { key1: '', key2: null, key3: undefined };
-      const result = renderTemplate(template, variables);
-      expect(result).toBe('AB{{key2}}C{{key3}}D');
+    it.each(renderTemplateCases)('$name', ({ template, variables, expected }) => {
+      expect(renderTemplate(template, variables)).toBe(expected);
     });
   });
 

--- a/__tests__/wiki.test.ts
+++ b/__tests__/wiki.test.ts
@@ -72,19 +72,6 @@ describe('wiki', async () => {
     ],
   );
 
-  describe('isWikiCheckFailure()', () => {
-    it('returns true for every FAILURE_* status', () => {
-      expect(isWikiCheckFailure(WIKI_STATUS.FAILURE_CHECKOUT)).toBe(true);
-      expect(isWikiCheckFailure(WIKI_STATUS.FAILURE_TERRAFORM_DOCS_INSTALL)).toBe(true);
-      expect(isWikiCheckFailure(WIKI_STATUS.FAILURE_TERRAFORM_DOCS_RUN)).toBe(true);
-    });
-
-    it('returns false for non-failure statuses', () => {
-      expect(isWikiCheckFailure(WIKI_STATUS.SUCCESS)).toBe(false);
-      expect(isWikiCheckFailure(WIKI_STATUS.DISABLED)).toBe(false);
-    });
-  });
-
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'wiki-test-'));
     wikiDir = join(tmpDir, '.wiki');
@@ -108,6 +95,19 @@ describe('wiki', async () => {
     if (existsSync(tmpDir)) {
       rmSync(tmpDir, { recursive: true });
     }
+  });
+
+  describe('isWikiCheckFailure()', () => {
+    it('returns true for every FAILURE_* status', () => {
+      expect(isWikiCheckFailure(WIKI_STATUS.FAILURE_CHECKOUT)).toBe(true);
+      expect(isWikiCheckFailure(WIKI_STATUS.FAILURE_TERRAFORM_DOCS_INSTALL)).toBe(true);
+      expect(isWikiCheckFailure(WIKI_STATUS.FAILURE_TERRAFORM_DOCS_RUN)).toBe(true);
+    });
+
+    it('returns false for non-failure statuses', () => {
+      expect(isWikiCheckFailure(WIKI_STATUS.SUCCESS)).toBe(false);
+      expect(isWikiCheckFailure(WIKI_STATUS.DISABLED)).toBe(false);
+    });
   });
 
   describe('checkoutWiki()', () => {
@@ -264,7 +264,7 @@ describe('wiki', async () => {
       // With modulePathIgnore: [], all modules in tf-modules directory should be processed
       // tf-modules directory contains: animal, kms, kms/examples/complete, s3-bucket-object, vpc-endpoint, zoo
       // So we expect: 6 module files + Home.md + _Sidebar.md + _Footer.md = 9 files
-      expect(files.length).toBe(9);
+      expect(files).toHaveLength(9);
 
       // Verify the specific files that should be generated
       const fileBasenames = files.map((f) => basename(f)).sort();

--- a/src/commit-analyzer.ts
+++ b/src/commit-analyzer.ts
@@ -4,8 +4,28 @@ import type { ConventionalCommitResult, ReleaseType } from '@/types';
 import { RELEASE_TYPE, SEMVER_MODE } from '@/utils/constants';
 
 /**
- * Pre-configured conventional commit parser using options taken verbatim from the
- * `conventional-changelog-conventionalcommits` preset's `createParserOpts()`:
+ * Matches GitHub-style revert commits (`Revert "<header>"` … `This reverts commit <hash>.`),
+ * capturing the original header and commit hash.
+ *
+ * This is the one parser option deliberately not taken verbatim from the
+ * `conventional-changelog-conventionalcommits` preset. The preset's pattern
+ * (`/^(?:Revert|revert:)\s"?([\s\S]+?)"?\s*This reverts commit (\w*)\./i`) backtracks
+ * super-linearly: the lazy `[\s\S]+?`, the optional `"?`, and the `\s*` all match the same
+ * characters, so a crafted message with a long whitespace run costs O(n²) — roughly 14 seconds
+ * at 100k characters. Requiring the captured header to end on a non-quote, non-whitespace
+ * character (`[\s\S]*?[^"\s]`) removes the ambiguity and keeps matching linear (<1ms at 100k)
+ * while accepting the same real-world revert messages. Only degenerate headers diverge: an
+ * empty quoted header (`Revert ""`) no longer matches, where the preset pattern captured a
+ * stray quote character as the header.
+ *
+ * Exported for the linear-time regression test; not part of the public API.
+ */
+export const REVERT_PATTERN = /^(?:Revert|revert:)\s"?([\s\S]*?[^"\s])"?\s*This reverts commit (\w*)\./i;
+
+/**
+ * Pre-configured conventional commit parser using options taken from the
+ * `conventional-changelog-conventionalcommits` preset's `createParserOpts()`
+ * (verbatim except `revertPattern` — see {@link REVERT_PATTERN}):
  *
  * @see https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-conventionalcommits/src/parser.js
  *
@@ -34,7 +54,8 @@ import { RELEASE_TYPE, SEMVER_MODE } from '@/utils/constants';
  *
  * - `revertPattern` / `revertCorrespondence` — Matches GitHub-style revert
  *   commits (`Revert "<header>" / This reverts commit <hash>.`), extracting the
- *   original header and commit hash.
+ *   original header and commit hash. The parsed revert fields are currently
+ *   unused by this action; the option is kept for preset fidelity.
  *
  * - `issuePrefixes` — Characters that prefix issue references (e.g. `#123`).
  */
@@ -43,7 +64,7 @@ const commitParser = new CommitParser({
   breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
   headerCorrespondence: ['type', 'scope', 'subject'],
   noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE'],
-  revertPattern: /^(?:Revert|revert:)\s"?([\s\S]+?)"?\s*This reverts commit (\w*)\./i,
+  revertPattern: REVERT_PATTERN,
   revertCorrespondence: ['header', 'hash'],
   issuePrefixes: ['#'],
 });

--- a/src/commit-analyzer.ts
+++ b/src/commit-analyzer.ts
@@ -57,7 +57,16 @@ export const REVERT_PATTERN = /^(?:Revert|revert:)\s"?([\s\S]*?[^"\s])"?\s*This 
  *   original header and commit hash. The parsed revert fields are currently
  *   unused by this action; the option is kept for preset fidelity.
  *
- * - `issuePrefixes` — Characters that prefix issue references (e.g. `#123`).
+ * - `issuePrefixes` — Deliberately overridden to `undefined` (the second divergence
+ *   from the preset, which uses `['#']` — also the library default). The references
+ *   output it feeds is unused by this action, and the regex the library builds from
+ *   it (`(?:.*?)??\s*([\w-.\/]*?)??(#)…`) is catastrophically super-linear: measured
+ *   at 10 seconds on a single 2,000-character line without a `#`. Since commit
+ *   messages come from pull requests, that is an attacker-triggerable CI stall.
+ *   The explicit `undefined` overrides the library default via the constructor's
+ *   `{ ...defaultOptions, ...options }` spread; if a future library version changes
+ *   that merge style the default would silently return, which the pathological-input
+ *   regression tests would catch as a test timeout.
  */
 const commitParser = new CommitParser({
   headerPattern: /^(\w*)(?:\((.*)\))?!?: (.*)$/,
@@ -66,12 +75,63 @@ const commitParser = new CommitParser({
   noteKeywords: ['BREAKING CHANGE', 'BREAKING-CHANGE'],
   revertPattern: REVERT_PATTERN,
   revertCorrespondence: ['header', 'hash'],
-  issuePrefixes: ['#'],
+  issuePrefixes: undefined,
 });
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Single-message detection
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Messages longer than this are reduced to a parse-safe digest before being handed to the parser.
+ *
+ * Even with `issuePrefixes` disabled, `conventional-commits-parser` substitutes the never-matching
+ * stub `/(?!.*)/` for the disabled regex — and that stub is itself quadratic, because the `.*`
+ * inside the lookahead walks to the end of the line at every scan position (measured: ~2.3s on a
+ * 100k-character line, growing quadratically). Bounding what reaches the parser caps that cost at
+ * ~60ms per message while `toParseSafeMessage()` preserves every output this module consumes.
+ * Real conventional commit messages — including large squash-merge bodies — sit far below this cap
+ * and always take the unmodified fast path.
+ *
+ * Exported for the oversized-message tests; not part of the public API.
+ */
+export const MAX_COMMIT_MESSAGE_PARSE_LENGTH = 16_384;
+
+/** Cap applied to the individual lines kept by `toParseSafeMessage()`. */
+const MAX_DIGEST_LINE_LENGTH = 1_024;
+
+/**
+ * Matches any line the parser's notes regex (`/^(?:\*\s+)?(BREAKING CHANGE|BREAKING-CHANGE):\s*(.*)/i`)
+ * would record as a breaking-change note. Kept in sync with that shape so the digest never drops a
+ * line the full parse would have counted.
+ */
+const BREAKING_NOTE_LINE = /^(?:\*\s+)?BREAKING[ -]CHANGE:/i;
+
+/**
+ * Reduces an oversized commit message to the lines that can influence this module's outputs.
+ *
+ * Everything `parseConventionalCommit()` returns derives from exactly two things: the header (first
+ * line → type, scope, subject, `!` indicator) and whether any breaking-change note exists (`!` or a
+ * `BREAKING CHANGE:` footer line). So for messages over `MAX_COMMIT_MESSAGE_PARSE_LENGTH`, parsing
+ * the header plus the first breaking-change footer line yields identical results to parsing the
+ * whole message — at bounded cost. The only lossy cases are absurd ones: a single header line over
+ * `MAX_DIGEST_LINE_LENGTH` characters gets its subject truncated, and note *text* (which this
+ * module never reads) is truncated.
+ *
+ * @param message - The trimmed commit message
+ * @returns The message itself when within the cap, otherwise the reduced digest
+ */
+function toParseSafeMessage(message: string): string {
+  if (message.length <= MAX_COMMIT_MESSAGE_PARSE_LENGTH) {
+    return message;
+  }
+
+  const lines = message.split(/\r?\n/);
+  const header = lines[0].slice(0, MAX_DIGEST_LINE_LENGTH);
+  const breakingLine = lines.slice(1).find((line) => BREAKING_NOTE_LINE.test(line));
+
+  return breakingLine === undefined ? header : `${header}\n\n${breakingLine.slice(0, MAX_DIGEST_LINE_LENGTH)}`;
+}
 
 /**
  * Parses a commit message according to the Conventional Commits specification
@@ -106,7 +166,7 @@ export function parseConventionalCommit(message: string): ConventionalCommitResu
     return null;
   }
 
-  const parsed = commitParser.parse(trimmed);
+  const parsed = commitParser.parse(toParseSafeMessage(trimmed));
 
   if (!parsed.type) {
     return null;

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,15 +50,16 @@ function initializeConfig(): Config {
     configInstance = createConfigFromInputs();
 
     // Validate that *.tf is not in excludePatterns
-    if (configInstance.moduleChangeExcludePatterns.some((pattern) => pattern === '*.tf')) {
+    if (configInstance.moduleChangeExcludePatterns.includes('*.tf')) {
       throw new TypeError('Exclude patterns cannot contain "*.tf" as it is required for module detection');
     }
-    if (configInstance.moduleAssetExcludePatterns.some((pattern) => pattern === '*.tf')) {
+    if (configInstance.moduleAssetExcludePatterns.includes('*.tf')) {
       throw new TypeError('Asset exclude patterns cannot contain "*.tf" as these files are required');
     }
 
-    // Validate WikiSidebar Changelog Max is a number and greater than zero
-    if (configInstance.wikiSidebarChangelogMax < 1 || Number.isNaN(configInstance.wikiSidebarChangelogMax)) {
+    // Validate WikiSidebar Changelog Max is greater than zero. (createConfigFromInputs rejects
+    // non-numeric number inputs, so NaN cannot reach this comparison.)
+    if (configInstance.wikiSidebarChangelogMax < 1) {
       throw new TypeError('Wiki Sidebar Change Log Max must be an integer greater than or equal to one');
     }
 

--- a/src/releases.ts
+++ b/src/releases.ts
@@ -35,13 +35,12 @@ const MAX_ORPHAN_TAG_LOOKUPS = 3;
  * This function fetches the list of releases for the repository specified in the configuration.
  * It returns the releases as an array of objects containing the title, body, and tag name.
  *
- * @param {ListReleasesParams} options - Optional configuration for the API request
+ * @param {ListReleasesParams} options - Optional pagination overrides, merged over the defaults
+ *   (`per_page: 100, page: 1`)
  * @returns {Promise<GitHubRelease[]>} A promise that resolves to an array of release details.
  * @throws {RequestError} Throws an error if the request to fetch releases fails.
  */
-export async function getAllReleases(
-  options: ListReleasesParams = { per_page: 100, page: 1 },
-): Promise<GitHubRelease[]> {
+export async function getAllReleases(options?: ListReleasesParams): Promise<GitHubRelease[]> {
   console.time('Elapsed time fetching releases'); // Start timing
   startGroup('Fetching repository releases');
 
@@ -55,6 +54,8 @@ export async function getAllReleases(
     let totalRequests = 0;
 
     const iterator = octokit.paginate.iterator(octokit.rest.repos.listReleases, {
+      per_page: 100,
+      page: 1,
       ...options,
       owner,
       repo,

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -12,13 +12,12 @@ type ListTagsParams = Omit<RestEndpointMethodTypes['repos']['listTags']['paramet
  * This function utilizes pagination to retrieve all tags with their commit SHAs,
  * returning them as an array of GitHubTag objects.
  *
- * @param {ListTagsParams} options - Optional configuration for the API request
- * @param {number} options.perPage - Number of items per page (default: 100)
+ * @param {ListTagsParams} options - Optional pagination overrides, merged over the defaults
+ *   (`per_page: 100, page: 1`)
  * @returns {Promise<GitHubTag[]>} A promise that resolves to an array of tag objects with name and commitSHA.
  * @throws {RequestError} Throws an error if the request to fetch tags fails.
  */
 export async function getAllTags(options?: ListTagsParams): Promise<GitHubTag[]> {
-  const { per_page = 100, page = 1, ...rest }: ListTagsParams = options ?? ({} as ListTagsParams);
   console.time('Elapsed time fetching tags');
   startGroup('Fetching repository tags');
 
@@ -30,14 +29,11 @@ export async function getAllTags(options?: ListTagsParams): Promise<GitHubTag[]>
 
     const tags: GitHubTag[] = [];
     let totalRequests = 0;
-    const paginationOptions: ListTagsParams = {
-      per_page,
-      page,
-      ...rest,
-    };
 
     for await (const response of octokit.paginate.iterator(octokit.rest.repos.listTags, {
-      ...paginationOptions,
+      per_page: 100,
+      page: 1,
+      ...options,
       owner,
       repo,
     })) {

--- a/src/terraform-docs.ts
+++ b/src/terraform-docs.ts
@@ -2,7 +2,7 @@ import { execFile, execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, win32 } from 'node:path';
 import { promisify } from 'node:util';
 import { context } from '@/context';
 import type { TerraformModule } from '@/terraform-module';
@@ -184,14 +184,18 @@ export function installTerraformDocs(terraformDocsVersion: string): void {
         .toString()
         .trim();
 
+      // Build the Windows destination path with the win32 path module so the separator is
+      // correct by construction (this branch only runs on Windows, but tests run elsewhere)
+      const terraformDocsExePath = win32.join(systemDir, 'terraform-docs.exe');
+
       info(`Copying executable to system dir (${systemDir})...`);
       execFileSync(powershellPath, [
         '-Command',
-        `Move-Item -Path "./terraform-docs/terraform-docs.exe" -Destination "${systemDir}\\terraform-docs.exe"`,
+        `Move-Item -Path "./terraform-docs/terraform-docs.exe" -Destination "${terraformDocsExePath}"`,
       ]);
 
       // terraform-docs version v0.21.0 af31cc6 windows/amd64
-      execFileSync(`${systemDir}\\terraform-docs.exe`, ['--version'], { stdio: 'inherit' });
+      execFileSync(terraformDocsExePath, ['--version'], { stdio: 'inherit' });
     } else {
       const commands = ['curl', 'tar', 'chmod', 'sudo'];
       const paths: Record<string, string> = {};

--- a/src/terraform-module.ts
+++ b/src/terraform-module.ts
@@ -631,9 +631,11 @@ export class TerraformModule {
 
     // Add release-specific info if relevant
     if (this.needsRelease()) {
-      lines.push(`   Release Type: ${this.getReleaseType()}`);
-      lines.push(`   Release Reasons: ${this.getReleaseReasons().join(', ')}`);
-      lines.push(`   Release Tag: ${this.getReleaseTag()}`);
+      lines.push(
+        `   Release Type: ${this.getReleaseType()}`,
+        `   Release Reasons: ${this.getReleaseReasons().join(', ')}`,
+        `   Release Tag: ${this.getReleaseTag()}`,
+      );
     }
 
     return lines.join('\n');
@@ -661,9 +663,9 @@ export class TerraformModule {
     let name = terraformDirectory
       .trim()
       .toLowerCase()
-      .replace(/[/\\]/g, config.tagDirectorySeparator) // Normalize backslashes and forward slashes to configured separator
-      .replace(/[^a-zA-Z0-9/._-]+/g, '-') // Replace invalid characters with hyphens (preserve alphanumeric, /, ., _, -)
-      .replace(/[/._-]{2,}/g, (match) => match[0]); // Normalize consecutive special characters to single instances
+      .replaceAll(/[/\\]/g, config.tagDirectorySeparator) // Normalize backslashes and forward slashes to configured separator
+      .replaceAll(/[^a-zA-Z0-9/._-]+/g, '-') // Replace invalid characters with hyphens (preserve alphanumeric, /, ., _, -)
+      .replaceAll(/[/._-]{2,}/g, (match) => match[0]); // Normalize consecutive special characters to single instances
 
     // Remove leading/trailing special characters safely without regex backtracking
     name = removeLeadingCharacters(name, VALID_TAG_DIRECTORY_SEPARATORS);

--- a/src/types/metadata.types.ts
+++ b/src/types/metadata.types.ts
@@ -34,7 +34,7 @@ export interface ActionInputMetadata {
    * The expected data type of the input for proper parsing and validation.
    * - 'string': Direct string value
    * - 'boolean': Parsed using getBooleanInput for proper true/false handling
-   * - 'number': Parsed using parseInt for integer conversion; non-numeric values are rejected
+   * - 'number': Strictly validated and parsed as a base-10 integer; anything else is rejected
    * - 'array': Comma-separated string parsed into array with deduplication
    */
   type: 'string' | 'boolean' | 'number' | 'array';

--- a/src/types/metadata.types.ts
+++ b/src/types/metadata.types.ts
@@ -34,7 +34,7 @@ export interface ActionInputMetadata {
    * The expected data type of the input for proper parsing and validation.
    * - 'string': Direct string value
    * - 'boolean': Parsed using getBooleanInput for proper true/false handling
-   * - 'number': Parsed using parseInt for integer conversion
+   * - 'number': Parsed using parseInt for integer conversion; non-numeric values are rejected
    * - 'array': Comma-separated string parsed into array with deduplication
    */
   type: 'string' | 'boolean' | 'number' | 'array';

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -99,9 +99,14 @@ export function createConfigFromInputs(): Config {
           );
         }
       } else if (type === 'number') {
-        // Handle number inputs with parseInt
+        // Handle number inputs with parseInt, rejecting non-numeric values so NaN never
+        // propagates into the config
         const input = getInput(inputName, { required });
-        value = Number.parseInt(input, 10);
+        const parsed = Number.parseInt(input, 10);
+        if (Number.isNaN(parsed)) {
+          throw new TypeError(`Invalid number value: '${input}'`);
+        }
+        value = parsed;
       } else {
         // Handle string inputs
         value = getInput(inputName, { required });

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -66,6 +66,50 @@ export const ACTION_INPUTS: Record<string, ActionInputMetadata> = {
 } as const;
 
 /**
+ * Reads a single action input and converts it according to its metadata type.
+ *
+ * @throws {TypeError} When a number input holds a non-numeric value, so NaN never propagates
+ *   into the config
+ */
+function getInputValue(inputName: string, { required, type }: ActionInputMetadata): unknown {
+  if (type === 'boolean') {
+    // Use getBooleanInput for boolean types for proper parsing
+    return getBooleanInput(inputName, { required });
+  }
+
+  if (type === 'array') {
+    // Handle array inputs as comma-separated values, trimmed and deduplicated
+    const input = getInput(inputName, { required });
+
+    if (!input || input.trim() === '') {
+      return [];
+    }
+
+    return Array.from(
+      new Set(
+        input
+          .split(',')
+          .map((item: string) => item.trim())
+          .filter(Boolean),
+      ),
+    );
+  }
+
+  if (type === 'number') {
+    // Handle number inputs with parseInt, rejecting non-numeric values
+    const input = getInput(inputName, { required });
+    const parsed = Number.parseInt(input, 10);
+    if (Number.isNaN(parsed)) {
+      throw new TypeError(`Invalid number value: '${input}'`);
+    }
+    return parsed;
+  }
+
+  // Handle string inputs
+  return getInput(inputName, { required });
+}
+
+/**
  * Creates a config object by reading inputs using GitHub Actions API and converting them
  * according to the metadata definitions. This provides a dynamic way to build the config
  * without manually mapping each input.
@@ -74,46 +118,9 @@ export function createConfigFromInputs(): Config {
   const config = {} as Config;
 
   for (const [inputName, metadata] of Object.entries(ACTION_INPUTS)) {
-    const { configKey, required, type } = metadata;
-
     try {
-      let value: unknown;
-
-      if (type === 'boolean') {
-        // Use getBooleanInput for boolean types for proper parsing
-        value = getBooleanInput(inputName, { required });
-      } else if (type === 'array') {
-        // Handle array inputs with special parsing
-        const input = getInput(inputName, { required });
-
-        if (!input || input.trim() === '') {
-          value = [];
-        } else {
-          value = Array.from(
-            new Set(
-              input
-                .split(',')
-                .map((item: string) => item.trim())
-                .filter(Boolean),
-            ),
-          );
-        }
-      } else if (type === 'number') {
-        // Handle number inputs with parseInt, rejecting non-numeric values so NaN never
-        // propagates into the config
-        const input = getInput(inputName, { required });
-        const parsed = Number.parseInt(input, 10);
-        if (Number.isNaN(parsed)) {
-          throw new TypeError(`Invalid number value: '${input}'`);
-        }
-        value = parsed;
-      } else {
-        // Handle string inputs
-        value = getInput(inputName, { required });
-      }
-
       // Safely assign to config using the configKey
-      Object.assign(config, { [configKey]: value });
+      Object.assign(config, { [metadata.configKey]: getInputValue(inputName, metadata) });
     } catch (error) {
       throw new Error(
         `Failed to process input '${inputName}': ${error instanceof Error ? error.message : String(error)}`,

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -96,13 +96,14 @@ function getInputValue(inputName: string, { required, type }: ActionInputMetadat
   }
 
   if (type === 'number') {
-    // Handle number inputs with parseInt, rejecting non-numeric values
+    // Strictly validate base-10 integers before parsing — parseInt alone would accept junk
+    // like '123abc', '1.5' (truncated), or '1O' (typo) and silently misconfigure the action.
+    // getInput() already trims surrounding whitespace.
     const input = getInput(inputName, { required });
-    const parsed = Number.parseInt(input, 10);
-    if (Number.isNaN(parsed)) {
-      throw new TypeError(`Invalid number value: '${input}'`);
+    if (!/^[+-]?\d+$/.test(input)) {
+      throw new TypeError(`Invalid integer value: '${input}'`);
     }
-    return parsed;
+    return Number.parseInt(input, 10);
   }
 
   // Handle string inputs

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -81,10 +81,7 @@ export function removeLeadingCharacters(input: string, charactersToRemove: strin
  * renderTemplate("Hello, {{name}}!", { name: null })
  */
 export function renderTemplate(template: string, variables: Record<string, string | undefined | null>): string {
-  return template.replace(/\{\{(\w+)\}\}/g, (placeholder, key) => {
-    const value = variables[key];
-    return value !== undefined && value !== null ? value : placeholder;
-  });
+  return template.replaceAll(/\{\{(\w+)\}\}/g, (placeholder, key) => variables[key] ?? placeholder);
 }
 
 /**

--- a/src/wiki.ts
+++ b/src/wiki.ts
@@ -223,17 +223,17 @@ export async function getWikiStatus(terraformModules: TerraformModule[]): Promis
  *   of characters for replacement and constructs a character class for the `pattern` regex.
  *
  * Replacement logic:
- * - `moduleName.replace(pattern, match => WIKI_TITLE_REPLACEMENTS[match])` matches each specified character
+ * - `moduleName.replaceAll(pattern, match => WIKI_TITLE_REPLACEMENTS[match])` matches each specified character
  *   in `moduleName` and replaces it with the mapped character from `WIKI_TITLE_REPLACEMENTS`.
  */
 function getWikiSlug(moduleName: string): string {
   const escapeForRegex = (char: string): string => {
-    return char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // Escape special characters for regex
+    return char.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`); // Escape special characters for regex
   };
 
   const pattern = new RegExp(`[${Object.keys(WIKI_TITLE_REPLACEMENTS).map(escapeForRegex).join('')}]`, 'g');
 
-  return moduleName.replace(pattern, (match) => WIKI_TITLE_REPLACEMENTS[match]);
+  return moduleName.replaceAll(pattern, (match) => WIKI_TITLE_REPLACEMENTS[match]);
 }
 
 /**
@@ -326,7 +326,7 @@ async function generateWikiTerraformModule(terraformModule: TerraformModule): Pr
     ref: ref,
     ref_comment: refComment,
     module_source: moduleSource,
-    module_name_terraform: terraformModule.name.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase(),
+    module_name_terraform: terraformModule.name.replaceAll(/[^a-zA-Z0-9]/g, '_').toLowerCase(),
   });
 
   const content = [
@@ -412,11 +412,11 @@ async function generateWikiSidebar(terraformModules: TerraformModule[]): Promise
       const heading = headingMatch[1].trim();
 
       // Convert heading into a valid ID string (keep only [a-zA-Z0-9-_]) But we need spaces to go to a '-'
-      const idString = heading.replace(/ +/g, '-').replace(/[^a-zA-Z0-9-_]/g, '');
+      const idString = heading.replaceAll(/ +/g, '-').replaceAll(/[^a-zA-Z0-9-_]/g, '');
 
       // Append the entry to changelogEntries
       changelogEntries.push(
-        `               <li><a href="${baselink}#${idString}">${heading.replace(/`/g, '')}</a></li>`,
+        `               <li><a href="${baselink}#${idString}">${heading.replaceAll('`', '')}</a></li>`,
       );
     }
 


### PR DESCRIPTION
## Summary

Clears every open SonarQube code smell, fixes two measured ReDoS defects reachable through PR commit messages, splits the Lint workflow into per-linter jobs, and codifies the underlying conventions in `CLAUDE.md` / `.claude/rules/tests.md` so these classes of findings don't recur.

## ReDoS hardening (`src/commit-analyzer.ts`)

Commit messages are PR-author-controlled and `semver-mode` defaults to `conventional-commits`, so super-linear parsing was an attacker-triggerable CI stall for any repo using this action. Three measured defects:

| Defect | Measured | Fix |
| --- | --- | --- |
| Preset `revertPattern` backtracks on whitespace runs (`[\s\S]+?"?\s*` ambiguity) | ~571ms @ 20k chars, ~14s @ 100k | Linearized as exported `REVERT_PATTERN` (`[\s\S]*?[^"\s]`) — <1ms @ 100k, verified behavior-identical on realistic revert messages |
| `conventional-commits-parser` issue-references regex (`(?:.*?)??\s*([\w-.\/]*?)??(#)…`), built from the library-default `issuePrefixes: ['#']` and run on every line | **10s on a single 2k-char line** | `issuePrefixes: undefined` — the references output is unused by this action; consumed outputs (type/scope/subject/breaking) verified byte-identical across a corpus |
| The library's "never-match" stub `/(?!.*)/` is itself O(n²) | 2.3s @ 100k chars | Messages >16k are reduced to a digest (header + first `BREAKING CHANGE:` footer line) before parsing — preserves all consumed outputs, unlike naive truncation which could silently drop a late breaking footer (a missed major bump) |

Five new pathological-input tests turn any regression into a test timeout. Filing an upstream issue against `conventional-commits-parser` is recommended follow-up (their stub fix is `/(?!)/`).

## SonarQube findings

- **Dedicated matchers** across 6 test files: `toHaveLength`, `toBeInstanceOf` / `.not.toBeInstanceOf`, `toBeNaN` (plus a repo-wide sweep of the same patterns, e.g. `Array.isArray(x)).toBe(true)`)
- **Parameterized tests**: the flagged trios in `commit-analyzer` / `terraform-module` / `string` folded into `it.each` tables (full 21-case `renderTemplate` table), plus the adjacent non-conventional-message cluster
- **Hooks above tests** in `wiki.test.ts`
- `.includes('*.tf')` over `.some()` equality (`config.ts`); single multi-arg `push()` (`terraform-module.ts`); `??` over ternary (`string.ts`); `replaceAll` over global-regex `replace` (`wiki.ts`, `string.ts`, `terraform-module.ts`)
- **Object-literal parameter default** (`releases.ts`): now `options?` spread over inline defaults — also fixes the real pitfall where `getAllReleases({ page: 2 })` silently dropped `per_page: 100`; `getAllTags` unified on the same idiom
- **Windows paths** (`terraform-docs.ts`): `win32.join` instead of hand-escaped separators — eliminates the flagged `\\` escapes rather than prettifying them
- **NaN validation** (`metadata.ts`): number inputs now fail fast at parse time with the input name in the error; the downstream `Number.isNaN` check was masking this for the single current number input but any future one would have let `NaN` through silently

## CI

- `lint.yml` renamed **Lint** and split into per-linter jobs — Format, Code, Types, Text, Actions, Secrets — for a cleaner check listing
- An aggregate **`Lint` gate job** (`needs:` all six, fails on failed/cancelled/skipped) preserves the previous single required-check name — ⚠️ if branch protection requires anything other than `Lint`, review it; the gate can be dropped in favor of requiring the granular jobs
- Consistency pass across all workflows: Title Case step names, named checkout steps, `test.yml` job key/permissions/trigger alignment, stale "master" comment removed; PR-facing job display names (`Check dist`, `TypeScript Tests`) deliberately untouched to avoid stranding required checks

## Conventions

New **Code quality** section in `CLAUDE.md` (linear regexes, preferred idioms, no object-literal defaults, boundary validation) and matcher/`it.each`/hook rules in `.claude/rules/tests.md`.

## Verification

Biome, `tsc --noEmit`, textlint, and Prettier all clean; **797 tests pass** (+8 new)